### PR TITLE
[refactor] Article Class를 record 타입으로 변경

### DIFF
--- a/src/main/java/com/fasttime/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/fasttime/domain/article/controller/ArticleController.java
@@ -58,8 +58,8 @@ public class ArticleController {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ResponseDTO.res(HttpStatus.CREATED, articleCommandUseCase.write(
                 new ArticleCreateServiceRequest(memberId,
-                    requestDto.getTitle(),
-                    requestDto.getContent(),
+                    requestDto.title(),
+                    requestDto.content(),
                     requestDto.isAnonymity()))));
     }
 
@@ -77,9 +77,9 @@ public class ArticleController {
             .body(ResponseDTO.res(HttpStatus.OK, articleCommandUseCase.update(
                 new ArticleUpdateServiceRequest(
                     memberId,
-                    requestDto.getMemberId(),
-                    requestDto.getTitle(),
-                    requestDto.isAnonymity(), requestDto.getContent()
+                    requestDto.memberId(),
+                    requestDto.title(),
+                    requestDto.isAnonymity(), requestDto.content()
                 ))));
     }
 
@@ -94,7 +94,7 @@ public class ArticleController {
         }
 
         articleCommandUseCase.delete(new ArticleDeleteServiceRequest(
-            requestDto.getArticleId(),
+            requestDto.articleId(),
             memberId,
             LocalDateTime.now()
         ));

--- a/src/main/java/com/fasttime/domain/article/dto/controller/request/ArticleCreateRequest.java
+++ b/src/main/java/com/fasttime/domain/article/dto/controller/request/ArticleCreateRequest.java
@@ -1,29 +1,11 @@
 package com.fasttime.domain.article.dto.controller.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
 
-@Getter
-public class ArticleCreateRequest {
+public record ArticleCreateRequest(
+    @NotBlank String title,
+    @NotBlank String content,
+    boolean isAnonymity
+) {
 
-    @NotBlank
-    private final String title;
-
-    @NotBlank
-    private final String content;
-
-    private final boolean anonymity;
-
-    @JsonCreator
-    public ArticleCreateRequest(
-        @JsonProperty(value = "title") String title,
-        @JsonProperty(value = "content") String content,
-        @JsonProperty(value = "anonymity") boolean anonymity) {
-
-        this.title = title;
-        this.content = content;
-        this.anonymity = anonymity;
-    }
 }

--- a/src/main/java/com/fasttime/domain/article/dto/controller/request/ArticleDeleteRequest.java
+++ b/src/main/java/com/fasttime/domain/article/dto/controller/request/ArticleDeleteRequest.java
@@ -1,24 +1,8 @@
 package com.fasttime.domain.article.dto.controller.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 
-@Getter
-public class ArticleDeleteRequest {
-
-    @NotNull
-    private final Long articleId;
-
-    @NotNull
-    private final Long memberId;
-
-    @JsonCreator
-    public ArticleDeleteRequest(
-        @JsonProperty("articleId") Long articleId,
-        @JsonProperty("memberId") Long memberId) {
-        this.articleId = articleId;
-        this.memberId = memberId;
-    }
+public record ArticleDeleteRequest(
+    @NotNull Long articleId,
+    @NotNull Long memberId) {
 }

--- a/src/main/java/com/fasttime/domain/article/dto/controller/request/ArticleUpdateRequest.java
+++ b/src/main/java/com/fasttime/domain/article/dto/controller/request/ArticleUpdateRequest.java
@@ -1,39 +1,12 @@
 package com.fasttime.domain.article.dto.controller.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 
-@Getter
-public class ArticleUpdateRequest {
-
-    @NotNull
-    private final Long articleId;
-
-    @NotNull
-    private final Long memberId;
-
-    private final boolean isAnonymity;
-
-    @NotBlank
-    private final String title;
-
-    @NotBlank
-    private final String content;
-
-    @JsonCreator
-    public ArticleUpdateRequest(
-        @JsonProperty("articleId") Long articleId,
-        @JsonProperty("memberId") Long memberId,
-        @JsonProperty("anonymity") boolean isAnonymity,
-        @JsonProperty("title") String title,
-        @JsonProperty("content") String content) {
-        this.articleId = articleId;
-        this.memberId = memberId;
-        this.isAnonymity = isAnonymity;
-        this.title = title;
-        this.content = content;
-    }
+public record ArticleUpdateRequest(
+    @NotNull Long articleId,
+    @NotNull Long memberId,
+    boolean isAnonymity,
+    @NotBlank String title,
+    @NotBlank String content) {
 }

--- a/src/main/java/com/fasttime/domain/article/dto/service/response/ArticleResponse.java
+++ b/src/main/java/com/fasttime/domain/article/dto/service/response/ArticleResponse.java
@@ -2,32 +2,18 @@ package com.fasttime.domain.article.dto.service.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-public class ArticleResponse {
+@Builder
+public record ArticleResponse(
+    Long id,
+    String title,
+    String content,
+    String nickname,
+    boolean anonymity,
+    int likeCount,
+    int hateCount,
+    LocalDateTime createdAt,
+    LocalDateTime lastModifiedAt
+) {
 
-    private final Long id;
-    private final String title;
-    private final String content;
-    private final String nickname;
-    private final boolean anonymity;
-    private final int likeCount;
-    private final int hateCount;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime lastModifiedAt;
-
-    @Builder
-    private ArticleResponse(Long id, String title, String content, String nickname, boolean anonymity,
-        int likeCount, int hateCount, LocalDateTime createdAt, LocalDateTime lastModifiedAt) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.nickname = nickname;
-        this.anonymity = anonymity;
-        this.likeCount = likeCount;
-        this.hateCount = hateCount;
-        this.createdAt = createdAt;
-        this.lastModifiedAt = lastModifiedAt;
-    }
 }

--- a/src/main/java/com/fasttime/domain/article/dto/service/response/ArticlesResponse.java
+++ b/src/main/java/com/fasttime/domain/article/dto/service/response/ArticlesResponse.java
@@ -2,32 +2,19 @@ package com.fasttime.domain.article.dto.service.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-public class ArticlesResponse {
+@Builder
+public record ArticlesResponse(
+    Long id,
+    String title,
+    String nickname,
+    boolean anonymity,
+    int commentCounts,
+    int likeCount,
+    int hateCount,
+    LocalDateTime createdAt,
+    LocalDateTime lastModifiedAt
+) {
 
-    private final Long id;
-    private final String title;
-    private final String nickname;
-    private final boolean anonymity;
-    private final int commentCounts;
-    private final int likeCount;
-    private final int hateCount;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime lastModifiedAt;
-
-    @Builder
-    private ArticlesResponse(Long id, String title, String nickname, boolean anonymity, int commentCounts, int likeCount,
-        int hateCount, LocalDateTime createdAt, LocalDateTime lastModifiedAt) {
-        this.id = id;
-        this.title = title;
-        this.nickname = nickname;
-        this.anonymity = anonymity;
-        this.commentCounts = commentCounts;
-        this.likeCount = likeCount;
-        this.hateCount = hateCount;
-        this.createdAt = createdAt;
-        this.lastModifiedAt = lastModifiedAt;
-    }
 }
+

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -38,7 +38,7 @@ public class CommentService {
             isChildComment ? getComment(createCommentRequestDTO.getParentCommentId()) : null;
         return commentRepository.save(Comment.builder()
                 .article(Article.builder()
-                    .id(postQueryService.queryById(articleId).getId())
+                    .id(postQueryService.queryById(articleId).id())
                     .build())
                 .member(memberService.getMember(memberId))
                 .content(createCommentRequestDTO.getContent())

--- a/src/main/java/com/fasttime/domain/record/service/RecordService.java
+++ b/src/main/java/com/fasttime/domain/record/service/RecordService.java
@@ -39,14 +39,14 @@ public class RecordService {
         ArticleResponse postResponse = postQueryService.queryById(
             createRecordRequestDTO.getPostId());
         Member member = memberService.getMember(memberId);
-        checkDuplicateRecords(member.getId(), postResponse.getId(),
+        checkDuplicateRecords(member.getId(), postResponse.id(),
             createRecordRequestDTO.getIsLike());
 
         recordRepository.save(
-            Record.builder().member(member).article(Article.builder().id(postResponse.getId()).build())
+            Record.builder().member(member).article(Article.builder().id(postResponse.id()).build())
                 .isLike(createRecordRequestDTO.getIsLike()).build());
 
-        postCommandService.likeOrHate(new ArticleLikeOrHateServiceRequest(postResponse.getId(),
+        postCommandService.likeOrHate(new ArticleLikeOrHateServiceRequest(postResponse.id(),
             createRecordRequestDTO.getIsLike(), true));
     }
 

--- a/src/test/java/com/fasttime/domain/article/unit/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fasttime/domain/article/unit/controller/ArticleControllerTest.java
@@ -20,7 +20,7 @@ class ArticleControllerTest extends ControllerUnitTestSupporter {
 
         @DisplayName("게시글을 저장할 수 있다.")
         @Test
-        void post_willSave() throws Exception {
+        void article_willSave() throws Exception {
 
             // given
             ArticleCreateRequest requestDto = new ArticleCreateRequest("title",

--- a/src/test/java/com/fasttime/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/member/docs/MemberControllerDocsTest.java
@@ -1,26 +1,25 @@
 package com.fasttime.domain.member.docs;
 
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.snippet.Attributes.key;
-
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasttime.docs.RestDocsSupport;
@@ -36,8 +35,8 @@ import com.fasttime.domain.member.response.MemberResponse;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.global.exception.ErrorCode;
 import com.fasttime.global.util.ResponseDTO;
+import jakarta.servlet.http.HttpSession;
 import java.util.Optional;
-import javax.servlet.http.HttpSession;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -47,7 +46,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 
-public class MemberControllerDocsTest extends RestDocsSupport {
+class MemberControllerDocsTest extends RestDocsSupport {
 
     private final MemberService memberService = mock(MemberService.class);
     private final MemberRepository memberRepository = mock(MemberRepository.class);

--- a/src/test/java/com/fasttime/domain/member/unit/controller/AdminControllerTest.java
+++ b/src/test/java/com/fasttime/domain/member/unit/controller/AdminControllerTest.java
@@ -96,7 +96,7 @@ public class AdminControllerTest {
 
             when(adminService.findOneReportedPost(anyLong())).thenReturn(article1);
             //when, then
-            mockMvc.perform(get("/api/v1/admin/{article_id}", article1.getId()))
+            mockMvc.perform(get("/api/v1/admin/{article_id}", article1.id()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.title").exists())

--- a/src/test/java/com/fasttime/domain/member/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/fasttime/domain/member/unit/controller/MemberControllerTest.java
@@ -43,7 +43,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
- class MemberControllerTest extends ControllerUnitTestSupporter {
+class MemberControllerTest extends ControllerUnitTestSupporter {
 
     @Nested
     @DisplayName("회원가입은")
@@ -169,7 +169,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
             @Test
             @DisplayName("성공한다: 프로필 수정")
-             void updateMember_Success() throws Exception {
+            void updateMember_Success() throws Exception {
                 // Given
                 Member member = new Member();
                 member.setId(1L);
@@ -272,7 +272,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
         @Test
         @DisplayName("실패한다. : 로그인하지 않은 사용자 정보 조회")
-         void testGetMyPageInfoWhenNotLoggedIn() throws Exception {
+        void testGetMyPageInfoWhenNotLoggedIn() throws Exception {
             // Given
             MockHttpSession session = new MockHttpSession();
 

--- a/src/test/java/com/fasttime/domain/member/unit/service/AdminServiceTest.java
+++ b/src/test/java/com/fasttime/domain/member/unit/service/AdminServiceTest.java
@@ -79,8 +79,8 @@ public class AdminServiceTest {
             List<ArticlesResponse> postList = adminService.findReportedPost(0);
 
             //then
-            Assertions.assertThat(postList.get(0).getTitle()).isEqualTo(article1.getTitle());
-            Assertions.assertThat(postList.get(1).getTitle()).isEqualTo(article2.getTitle());
+            Assertions.assertThat(postList.get(0).title()).isEqualTo(article1.getTitle());
+            Assertions.assertThat(postList.get(1).title()).isEqualTo(article2.getTitle());
         }
 
         @DisplayName("신고된 게시물들이 없어 조회 할 수 없다.")
@@ -118,7 +118,7 @@ public class AdminServiceTest {
             ArticleResponse oneReportedPost = adminService.findOneReportedPost(1L);
 
             //then
-            Assertions.assertThat(oneReportedPost.getTitle()).isEqualTo(article1.getTitle());
+            Assertions.assertThat(oneReportedPost.title()).isEqualTo(article1.getTitle());
         }
 
         @DisplayName("신고된 게시글이 존재하지 않아 조회 할 수 없다.")

--- a/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
+++ b/src/test/java/com/fasttime/domain/record/unit/service/RecordServiceTest.java
@@ -115,7 +115,7 @@ public class RecordServiceTest {
             ArticleResponse post = ArticleResponse.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.of(
-                Record.builder().member(member).article(Article.builder().id(post.getId()).build())
+                Record.builder().member(member).article(Article.builder().id(post.id()).build())
                     .isLike(true).build());
 
             given(postQueryService.queryById(any(Long.class))).willReturn(post);
@@ -139,7 +139,7 @@ public class RecordServiceTest {
             ArticleResponse post = ArticleResponse.builder().id(1L).build();
             Member member = Member.builder().id(1L).build();
             Optional<Record> record = Optional.of(
-                Record.builder().member(member).article(Article.builder().id(post.getId()).build())
+                Record.builder().member(member).article(Article.builder().id(post.id()).build())
                     .isLike(false).build());
 
             given(postQueryService.queryById(any(Long.class))).willReturn(post);

--- a/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
+++ b/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasttime.domain.article.controller.ArticleController;
 import com.fasttime.domain.article.service.ArticleCommandService;
 import com.fasttime.domain.article.service.ArticleQueryService;
+import com.fasttime.domain.member.controller.MemberController;
+import com.fasttime.domain.member.repository.MemberRepository;
+import com.fasttime.domain.member.service.MemberService;
 import org.apache.catalina.security.SecurityConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -13,7 +16,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(value = ArticleController.class,
+@WebMvcTest(value = {ArticleController.class, MemberController.class},
     excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)},
     excludeAutoConfiguration = SecurityAutoConfiguration.class)
@@ -31,5 +34,10 @@ public abstract class ControllerUnitTestSupporter {
     @MockBean
     protected ArticleQueryService postQueryService;
 
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected MemberRepository memberRepository;
 
 }


### PR DESCRIPTION
motivation:
- Article 도메인의 dto들은 모두 불변클래스입니다. java 17 부터는 이러한 불변클래스를 record 타입으로 쉽게 구현할 수 있게 되었습니다. Article 도메인의 dto들을 record로 변환합니다.

modification:
- Article domain Dto record 타입으로 변경