### PR TITLE
[refactor] : 개발서버 전용 cors filter 추가

### DIFF
--- a/src/main/java/com/fasttime/global/config/CorsConfig.java
+++ b/src/main/java/com/fasttime/global/config/CorsConfig.java
@@ -1,7 +1,11 @@
 package com.fasttime.global.config;
 
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
@@ -9,12 +13,29 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 public class CorsConfig {
 
+    @Value("${spring.cors.allow-origins}")
+    private List<String> allowOrigins;
+
     @Bean
-    public CorsFilter corsFilter() {
+    @Profile("prod")
+    public CorsFilter prodCorsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.setAllowedOrigins(allowOrigins);
+        corsConfiguration.setAllowedHeaders(List.of("*"));
+        corsConfiguration.setAllowedMethods(
+            Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        return new CorsFilter(source);
+    }
+
+    @Bean
+    @Profile(value = {"local", "develop"})
+    public CorsFilter developCorsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOriginPattern("https://www.boocam.net");
+        config.setAllowedOrigins(allowOrigins);
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.addExposedHeader("*");

--- a/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.filter.CorsFilter;
 
 
 /**
@@ -26,9 +26,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-public class SpringSecurityConfig implements WebMvcConfigurer {
+public class SpringSecurityConfig {
+
     private final JwtProvider jwtProvider;
-    private final CorsConfig corsConfig;
+    private final CorsFilter corsFilter;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private static final String[] PERMIT_URL_ARRAY = {
@@ -50,21 +51,22 @@ public class SpringSecurityConfig implements WebMvcConfigurer {
                 configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(requests -> requests
                 .requestMatchers(PERMIT_URL_ARRAY).permitAll()
-                .requestMatchers(HttpMethod.GET,"api/v1/article", "api/v2/articles").permitAll()
+                .requestMatchers(HttpMethod.GET, "api/v1/article", "api/v2/articles").permitAll()
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated())
             .formLogin(AbstractHttpConfigurer::disable)
-            .addFilter(corsConfig.corsFilter())
+            .addFilter(corsFilter)
             .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
                 UsernamePasswordAuthenticationFilter.class)
-            .exceptionHandling(AuthenticationManager -> AuthenticationManager
+            .exceptionHandling(authenticationManager -> authenticationManager
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .accessDeniedHandler(jwtAccessDeniedHandler));
+
         return http.build();
     }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
 }


### PR DESCRIPTION
motivation:
- 개발서버 전용 CORS와 실제 프로덕션의 CORS는 다릅니다. 이 문제를 해결하기 위해서 각각 프로파일에 맞는 Bean을 로딩할 수 있게 만들 필요가 있습니다.

modification:
- Profile에 맞게 Bean에 등록되는 `CorsFilter` 분리
- `CorsConfig.java` 를 로딩하는 것이 아닌 `CorsFilter.java`을 로딩하게끔 변경