### PR TITLE
[refactor] : 로컬 테스트 이메일 서비스 분리

### DIFF
--- a/src/main/java/com/fasttime/domain/member/controller/EmailController.java
+++ b/src/main/java/com/fasttime/domain/member/controller/EmailController.java
@@ -1,7 +1,7 @@
 package com.fasttime.domain.member.controller;
 
 import com.fasttime.domain.member.dto.request.EmailRequest;
-import com.fasttime.domain.member.service.EmailService;
+import com.fasttime.domain.member.service.EmailUseCase;
 import com.fasttime.global.util.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,12 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class EmailController {
 
-    private final EmailService emailService;
+    private final EmailUseCase emailUseCase;
 
     @PostMapping("/api/v1/confirm")
     public ResponseEntity<ResponseDTO<String>> mailConfirm(@RequestBody EmailRequest emailRequest)
         throws Exception {
-        emailService.sendVerificationEmail(emailRequest.getEmail());
+        emailUseCase.sendVerificationEmail(emailRequest.getEmail());
         return ResponseEntity.ok(
             ResponseDTO.res(HttpStatus.OK, "인증 이메일이 성공적으로 전송되었습니다.", null)
         );
@@ -33,7 +33,7 @@ public class EmailController {
         @RequestParam("email") String email,
         @PathVariable("code") String code) {
 
-        boolean isVerified = emailService.verifyEmailCode(email, code);
+        boolean isVerified = emailUseCase.verifyEmailCode(email, code);
         if (isVerified) {
             return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, "이메일 인증 성공.", true));
         } else {

--- a/src/main/java/com/fasttime/domain/member/service/EmailUseCase.java
+++ b/src/main/java/com/fasttime/domain/member/service/EmailUseCase.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.member.service;
+
+import jakarta.mail.MessagingException;
+import java.io.UnsupportedEncodingException;
+
+public interface EmailUseCase {
+
+    String sendVerificationEmail(String to) throws MessagingException, UnsupportedEncodingException;
+
+    boolean verifyEmailCode(String email, String code);
+}

--- a/src/main/java/com/fasttime/domain/member/service/LocalEmailService.java
+++ b/src/main/java/com/fasttime/domain/member/service/LocalEmailService.java
@@ -1,0 +1,60 @@
+package com.fasttime.domain.member.service;
+
+import com.fasttime.domain.member.exception.EmailSendingException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.MailException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Profile("local || test")
+@Service
+@Transactional
+public class LocalEmailService implements EmailUseCase {
+
+    private final Map<String, String> verificationCodes = new HashMap<>();
+
+    @Override
+    public String sendVerificationEmail(String to) {
+        String authCode = generateAuthCode();
+        try {
+            log.info("send verification email...");
+            log.info("target: {}", to);
+            log.info("code: {}", authCode);
+            verificationCodes.put(to, authCode);
+            return authCode;
+        } catch (MailException ex) {
+            throw new EmailSendingException();
+        }
+    }
+
+    @Override
+    public boolean verifyEmailCode(String email, String code) {
+        String storedCode = verificationCodes.get(email);
+        return storedCode != null && storedCode.equals(code);
+    }
+
+    private String generateAuthCode() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder();
+        for (int i = 0; i < 8; i++) {
+            int index = random.nextInt(3);
+            switch (index) {
+                case 0:
+                    key.append((char) (random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    key.append((char) (random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    key.append(random.nextInt(10));
+                    break;
+            }
+        }
+        return key.toString();
+    }
+}

--- a/src/main/java/com/fasttime/domain/member/service/ProdEmailService.java
+++ b/src/main/java/com/fasttime/domain/member/service/ProdEmailService.java
@@ -22,10 +22,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Profile("!local || !test")
+@Profile("prod")
 @RequiredArgsConstructor
 @Transactional
-public class EmailService implements EmailUseCase{
+public class ProdEmailService implements EmailUseCase{
 
     private final JavaMailSender javaMailSender;
 

--- a/src/main/java/com/fasttime/global/config/EmailConfig.java
+++ b/src/main/java/com/fasttime/global/config/EmailConfig.java
@@ -5,9 +5,11 @@ import java.util.Properties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+@Profile("prod")
 @Configuration
 public class EmailConfig {
 

--- a/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
+++ b/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
@@ -11,7 +11,7 @@ import com.fasttime.domain.member.controller.EmailController;
 import com.fasttime.domain.member.controller.MemberController;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.member.service.AdminService;
-import com.fasttime.domain.member.service.EmailService;
+import com.fasttime.domain.member.service.EmailUseCase;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.domain.memberArticleLike.controller.MemberArticleLikeRestController;
 import com.fasttime.domain.memberArticleLike.service.MemberArticleLikeService;
@@ -61,7 +61,7 @@ public abstract class ControllerUnitTestSupporter {
     protected SecurityUtil securityUtil;
 
     @MockBean
-    protected EmailService emailService;
+    protected EmailUseCase emailUseCase;
 
     @MockBean
     protected AdminService adminService;


### PR DESCRIPTION
motivation:
- local 이나 develop 의 경우 이메일을 실제로 사용하지 않는 경우도 있습니다. 이 문제를 해결하기 위해 테스트 전용 EmailService를 생성하게 되었습니다.

modification:
- `EmailUseCase.java` 분리
- `LocalEmailService.java` 생성