### PR TITLE
[fix] : 이메일 테스트코드 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/member/controller/EmailController.java
+++ b/src/main/java/com/fasttime/domain/member/controller/EmailController.java
@@ -3,6 +3,7 @@ package com.fasttime.domain.member.controller;
 import com.fasttime.domain.member.dto.request.EmailRequest;
 import com.fasttime.domain.member.service.EmailUseCase;
 import com.fasttime.global.util.ResponseDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,9 @@ public class EmailController {
     private final EmailUseCase emailUseCase;
 
     @PostMapping("/api/v1/confirm")
-    public ResponseEntity<ResponseDTO<String>> mailConfirm(@RequestBody EmailRequest emailRequest)
+    public ResponseEntity<ResponseDTO<String>> mailConfirm(@Valid @RequestBody EmailRequest emailRequest)
         throws Exception {
-        emailUseCase.sendVerificationEmail(emailRequest.getEmail());
+        emailUseCase.sendVerificationEmail(emailRequest.email());
         return ResponseEntity.ok(
             ResponseDTO.res(HttpStatus.OK, "인증 이메일이 성공적으로 전송되었습니다.", null)
         );

--- a/src/main/java/com/fasttime/domain/member/dto/request/EmailRequest.java
+++ b/src/main/java/com/fasttime/domain/member/dto/request/EmailRequest.java
@@ -3,21 +3,10 @@ package com.fasttime.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-public class EmailRequest {
-
-
+public record EmailRequest(
     @NotBlank(message = "이메일은 필수 항목입니다.")
     @Email(message = "올바른 이메일 형식이어야 합니다.")
-    private String email;
-
-    @NotBlank(message = "코드는 필수 항목입니다.")
-    @Size(min = 8, max = 8, message = "코드는 8자여야 합니다.")
-    private String code;
-
+    String email
+) {
 }

--- a/src/main/java/com/fasttime/domain/member/service/LocalEmailService.java
+++ b/src/main/java/com/fasttime/domain/member/service/LocalEmailService.java
@@ -1,9 +1,9 @@
 package com.fasttime.domain.member.service;
 
 import com.fasttime.domain.member.exception.EmailSendingException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.mail.MailException;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class LocalEmailService implements EmailUseCase {
 
-    private final Map<String, String> verificationCodes = new HashMap<>();
+    private final Map<String, String> verificationCodes = new ConcurrentHashMap<>();
 
     @Override
     public String sendVerificationEmail(String to) {

--- a/src/main/java/com/fasttime/domain/member/service/ProdEmailService.java
+++ b/src/main/java/com/fasttime/domain/member/service/ProdEmailService.java
@@ -8,9 +8,10 @@ import jakarta.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
@@ -31,7 +32,7 @@ public class ProdEmailService implements EmailUseCase{
 
     private static final String TEST_ID_EMAIL = "fasttime123@naver.com";
 
-    private final Map<String, String> verificationCodes = new HashMap<>();
+    private final Map<String, String> verificationCodes = new ConcurrentHashMap<>();
 
     @Override
     public String sendVerificationEmail(String to)
@@ -79,14 +80,14 @@ public class ProdEmailService implements EmailUseCase{
         String title = "회원가입 인증 번호";
 
         MimeMessage message = javaMailSender.createMimeMessage();
-        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, StandardCharsets.UTF_8.name());
 
         String emailTemplate = loadEmailTemplate("email_template.html");
 
         emailTemplate = emailTemplate.replace("{{authCode}}", authCode);
 
         helper.setSubject(title);
-        helper.setFrom(new InternetAddress(setFrom, "boocam", "UTF-8"));
+        helper.setFrom(new InternetAddress(setFrom, "boocam", StandardCharsets.UTF_8.name()));
         helper.setTo(to);
         helper.setText(emailTemplate, true);
 
@@ -98,7 +99,7 @@ public class ProdEmailService implements EmailUseCase{
             Resource resource = new ClassPathResource("templates/" + templateName);
             InputStream inputStream = resource.getInputStream();
             byte[] templateBytes = inputStream.readAllBytes();
-            return new String(templateBytes, "UTF-8");
+            return new String(templateBytes, StandardCharsets.UTF_8);
         } catch (IOException ex) {
             throw new EmailTemplateLoadException();
         }

--- a/src/test/java/com/fasttime/domain/member/controller/EmailControllerTest.java
+++ b/src/test/java/com/fasttime/domain/member/controller/EmailControllerTest.java
@@ -1,69 +1,89 @@
 package com.fasttime.domain.member.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasttime.domain.member.dto.request.EmailRequest;
 import com.fasttime.util.ControllerUnitTestSupporter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.http.MediaType;
 
 class EmailControllerTest extends ControllerUnitTestSupporter {
 
     @Nested
-    @DisplayName("이메일 확인 API 테스트")
+    @DisplayName("이메일 인증코드 전송 API 테스트")
     class testMailConfirm {
 
-//        @Test
-//        @DisplayName("성공한다. : 등록된 이메일")
-//        public void testMailConfirm_RegisteredEmail() throws Exception {
-//            String email = "test@example.com";
-//
-//            when(memberService.isEmailExistsInFcmember(anyString())).thenReturn(true);
-//            when(emailService.sendSimpleMessage(anyString())).thenReturn("123456");
-//
-//            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/emailconfirm")
-//                    .contentType(MediaType.APPLICATION_JSON)
-//                    .content("{\"email\": \"" + email + "\"}"))
-//                .andExpect(MockMvcResultMatchers.status().isOk())
-//                .andExpect(MockMvcResultMatchers.content().string("success"));
-//
-//            verify(emailService).sendSimpleMessage(email);
-//        }
-//
-//        @Test
-//        @DisplayName("실패한다. : 등록되지 않은 이메일")
-//        public void testMailConfirm_UnregisteredEmail() throws Exception {
-//            String email = "unregistered@example.com";
-//
-//            when(memberService.isEmailExistsInFcmember(anyString())).thenReturn(
-//                false);
-//
-//            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/emailconfirm")
-//                    .contentType(MediaType.APPLICATION_JSON)
-//                    .content("{\"email\": \"" + email + "\"}"))
-//                .andExpect(MockMvcResultMatchers.status().isBadRequest())
-//                .andExpect(MockMvcResultMatchers.content().string("FastCampus에 등록된 이메일이 아닙니다."));
-//
-//            verify(emailService, never()).sendSimpleMessage(email);
-//        }
+        @Test
+        @DisplayName("성공한다. : 등록된 이메일")
+        void testMailConfirm_RegisteredEmail() throws Exception {
+            String email = "test@example.com";
+            EmailRequest request = new EmailRequest(email);
+
+            when(memberService.isEmailExistsInFcmember(anyString())).thenReturn(true);
+            when(emailUseCase.sendVerificationEmail(anyString())).thenReturn("123456");
+
+            mockMvc.perform(post("/api/v1/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk());
+
+            verify(emailUseCase).sendVerificationEmail(email);
+        }
+
+        @Test
+        @DisplayName("실패한다. : 이메일 형식이 아닌 경우")
+        void requestEmail_isNotEmailFormat_will400Error() throws Exception {
+            String email = "this_is_not_email_format_request";
+            EmailRequest request = new EmailRequest(email);
+
+            when(memberService.isEmailExistsInFcmember(anyString())).thenReturn(false);
+
+            mockMvc.perform(post("/api/v1/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isBadRequest());
+
+            verify(emailUseCase, never()).sendVerificationEmail(email);
+        }
     }
 
+    @Nested
+    @DisplayName("이메일 인증코드 전송 API 테스트")
+    class testEmailVerify {
 
-    @Test
-    @DisplayName("이메일 인증 코드를 확인한다.")
-    void Element_Email() throws Exception {
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("emailCode", "123456");
+        @Test
+        @DisplayName("이메일 인증 코드를 확인한다.")
+        void server_hasVerificationCode_will200() throws Exception {
+            // given
+            String email = "test@email.com";
+            when(emailUseCase.verifyEmailCode(anyString(), anyString())).thenReturn(true);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/verify/123456")
-                .session(session))
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.success").value(true));
+            // when then
+            mockMvc.perform(get("/api/v1/verify/{code}", 12345)
+                    .queryParam("email", email))
+                .andExpect(status().isOk());
+        }
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/verify/111111")
-                .session(session))
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.success").value(false));
+        @Test
+        @DisplayName("이메일 인증 코드가 일치하지 않으면 실패한다.")
+        void server_doesntHave_verificationCode_will200() throws Exception {
+
+            // given
+            String email = "test@email.com";
+            when(emailUseCase.verifyEmailCode(anyString(), anyString())).thenReturn(false);
+
+            // when then
+            mockMvc.perform(get("/api/v1/verify/{code}", 11111)
+                    .queryParam("email", email))
+                .andExpect(status().isBadRequest());
+        }
     }
 }


### PR DESCRIPTION
motivation:
- 이메일 api에 불필요한 요청 정보들과 로직이 존재하여 수정할 필요가 생겄습니다.
- 이메일 인증에서 HashMap은 동시성에 대해 보증할 수 없습니다. 이를 해결하기 위한 새로운 자료구조를 채택할 필요가 생겼습니다.
- 이메일 api test를 수정할 필요가 생겼습니다.

modification:
- `ConcurrentHashMap` 도입
- `EmailRequest`에서 `code` 제거
- `EmailControllerTest.java` 수정