### PR TITLE
[fix] 댓글 adoc 파일 수정

### DIFF
--- a/src/docs/asciidoc/comment/comment-api.adoc
+++ b/src/docs/asciidoc/comment/comment-api.adoc
@@ -34,7 +34,7 @@ include::{snippets}/comment-create/response-fields.adoc[]
 === HttpRequest
 
 include::{snippets}/comments-search/http-request.adoc[]
-include::{snippets}/comments-search/request-parameters.adoc[]
+include::{snippets}/comments-search/query-parameters.adoc[]
 
 === HttpResponse
 

--- a/src/docs/asciidoc/comment/comment-api.adoc
+++ b/src/docs/asciidoc/comment/comment-api.adoc
@@ -27,9 +27,9 @@ include::{snippets}/comment-create/response-fields.adoc[]
 
 **Guide**
 
-- 마이페이지에서 회원이 남긴 댓글 목록 조회는 memberId를 요청 파라미터에 담아 요청해주세요.
-- 게시글 상세 페이지에서 게시글의 댓글 목록 조회는 articleId를 요청 파라미터에 담아 요청해주세요.
-- 댓글에 대한 대댓글 조회는 parentCommentId를 파라미터로 담아 요청해주세요.
+- 마이페이지에서 회원이 남긴 댓글 목록 조회는 memberId를 쿼리 파라미터에 담아 요청해주세요.
+- 게시글 상세 페이지에서 게시글의 댓글 목록 조회는 articleId를 쿼리 파라미터에 담아 요청해주세요.
+- 댓글에 대한 대댓글 조회는 parentCommentId를 쿼리 파라미터에 담아 요청해주세요.
 
 === HttpRequest
 


### PR DESCRIPTION
## 💡 Motivation
- 버전 마이그레이션 후 snippet 파일 명이 변경됨에 따라 adoc 도 수정해야 합니다. 

## 📌 Changes
- 댓글 adoc 파일의 snippet 파일 중 request-parameters 를 query-parameters로 수정
- path 파라미터와 헷갈리지 않도록 워딩 수정