### PR TITLE
[fix] 댓글 등록 500 에러 해결

### DIFF
--- a/src/main/java/com/fasttime/domain/article/service/ArticleEventListener.java
+++ b/src/main/java/com/fasttime/domain/article/service/ArticleEventListener.java
@@ -9,6 +9,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
 @Component
@@ -20,7 +21,7 @@ public class ArticleEventListener {
         this.articleRepository = articleRepository;
     }
 
-    @EventListener
+    @TransactionalEventListener
     public void updateCommentCount(CommentCreateEvent event) {
         Article article = articleRepository.findById(event.articleId())
             .orElseThrow(() -> new ArticleNotFoundException(event.articleId()));
@@ -28,7 +29,7 @@ public class ArticleEventListener {
         article.increaseCommentCount();
     }
 
-    @EventListener
+    @TransactionalEventListener
     public void updateCommentCount(CommentDeleteEvent event) {
         Article article = articleRepository.findById(event.articleId())
             .orElseThrow(() -> new ArticleNotFoundException(event.articleId()));

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -34,7 +34,8 @@ public class CommentRestController {
     private final SecurityUtil securityUtil;
 
     @PostMapping("/{articleId}")
-    public ResponseEntity<ResponseDTO<Object>> createComment(@PathVariable long articleId,
+    public ResponseEntity<ResponseDTO<Object>> createComment(
+        @PathVariable(name = "articleId") long articleId,
         @Valid @RequestBody CreateCommentRequestDTO createCommentRequestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
             ResponseDTO.res(HttpStatus.CREATED, "댓글을 성공적으로 등록했습니다.",
@@ -65,7 +66,7 @@ public class CommentRestController {
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<ResponseDTO<CommentResponseDTO>> updateComment(
-        @PathVariable long commentId,
+        @PathVariable(name = "commentId") long commentId,
         @Valid @RequestBody UpdateCommentRequestDTO updateCommentRequestDTO) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글 내용을 성공적으로 수정했습니다.",
@@ -75,7 +76,7 @@ public class CommentRestController {
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ResponseDTO<CommentResponseDTO>> deleteComment(
-        @PathVariable long commentId) {
+        @PathVariable(name = "commentId") long commentId) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 삭제했습니다.",
                 commentService.deleteComment(commentId, securityUtil.getCurrentMemberId())));


### PR DESCRIPTION
## 💡 Motivation
- 기존에 사용 중이던 @EventListener는 event를 publishing 하는 코드 시점에 바로 publishing합니다. 
- 그런데 게시글의 댓글 개수 업데이트는 메인 작업이 아닌 서브 작업이기 때문에 댓글 등록 기능에 영향을 주면 안됩니다. 
- 따라서 댓글 등록 트랜잭션이 커밋된 이후에 댓글 개수 업데이트 이벤트 리스너가 작동하도록 @TransactionalEventListner를 사용해야 합니다. 

## 📌 Changes
- Path Parameter 명시
- 이벤트 리스너를 @TransactionalEventListner로 수정

closes #171 