### PR TITLE
[refactor]  배포 서버 데이터 베이스 RDS 이전

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@
 .gradle
 **/build/
 !src/**/build/
+out/
 *.yml
 *.yaml
+
 # Ignore Gradle GUI config
 gradle-app.setting
 
@@ -147,10 +149,17 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Config yaml
 src/main/resources/application.yaml
 **/application-*.yaml
 **/*-prod.yaml
+
+# Log
 log/
+
 # End of https://www.toptal.com/developers/gitignore/api/intellij,macos,windows,java
 bin/
 .env
+
+# Q Class
+src/main/generated/


### PR DESCRIPTION
## 💡 Motivation
- RDS 비용 절감을 위해 prod, dev 서버 모두 하나의 RDS 서버를 사용하도록 수정해야 합니다. 
- 따라서 submodule 설정 yaml 파일을 수정해야 합니다. 
- 추가적으로, .gitignore 파일에 누락된 내용이 있어 추가해야 합니다. 

## 📌 Changes
- submodule yaml 파일 수정
- .gitignore에 out/, src/main/generated/ 추가