### PR TITLE
[Feature] 태그 등록문제 해결 및 리뷰 조회 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,7 +1,7 @@
 ifndef::snippets[]
 :snippets: ../../build/generated-snippets
 endif::[]
-= FastTime API 문서
+= Boocam API 문서
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -17,6 +17,7 @@ endif::[]
 === link:admin/admin-api.html[어드민 API, window=blank]
 === link:report/report-api.html[신고 API, window=blank]
 === link:member_article_like/memberArticleLike-api.html[좋아요/싫어요 API, window=blank]
+=== link:review/review-api.html[리뷰 API, window=blank]
 
 == API Common Response
 [[overview-http-status-code]]

--- a/src/docs/asciidoc/review/review-api.adoc
+++ b/src/docs/asciidoc/review/review-api.adoc
@@ -1,0 +1,106 @@
+= Review REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+
+[[Review-Create]]
+== 리뷰 작성
+
+리뷰 작성 API 입니다.
+
+
+=== HttpRequest
+
+include::{snippets}/review-create/http-request.adoc[]
+include::{snippets}/review-create/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/review-create/http-response.adoc[]
+include::{snippets}/review-create/response-fields.adoc[]
+
+[[Review-Delete]]
+== 리뷰 삭제
+
+리뷰 삭제 API 입니다.
+
+
+=== HttpRequest
+
+include::{snippets}/review-delete/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/review-delete/http-response.adoc[]
+include::{snippets}/review-delete/response-fields.adoc[]
+
+[[Review-Update]]
+== 리뷰 수정
+
+리뷰 수정 API 입니다.
+
+
+=== HttpRequest
+
+include::{snippets}/review-update/http-request.adoc[]
+include::{snippets}/review-update/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/review-update/http-response.adoc[]
+include::{snippets}/review-update/response-fields.adoc[]
+
+[[Review-Get-All]]
+== 전체 리뷰 조회
+
+전체 리뷰를 조회하는 API 입니다.
+
+* sortBy로 최신순, 별점순 정렬 가능 (createdAt  /  rating)
+
+=== HttpRequest
+
+include::{snippets}/reviews-get-all/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/reviews-get-all/http-response.adoc[]
+include::{snippets}/reviews-get-all/response-fields.adoc[]
+
+[[Review-Get-BootCamp]]
+== 부트캠프별 리뷰 조회
+
+부트캠프별 리뷰를 조회하는 API 입니다.
+
+* sortBy로 최신순, 별점순 정렬 가능 (createdAt  /  rating)
+
+=== HttpRequest
+
+include::{snippets}/reviews-get-bootcamp/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/reviews-get-bootcamp/http-response.adoc[]
+include::{snippets}/reviews-get-bootcamp/response-fields.adoc[]
+
+[[Review-Get-Summary]]
+== 부트캠프별 리뷰 요약
+
+부트캠프별 리뷰를 요악하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/reviews-get-summary/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/reviews-get-summary/http-response.adoc[]
+include::{snippets}/reviews-get-summary/response-fields.adoc[]
+
+
+
+
+
+

--- a/src/docs/asciidoc/review/review-api.adoc
+++ b/src/docs/asciidoc/review/review-api.adoc
@@ -31,6 +31,7 @@ include::{snippets}/review-create/response-fields.adoc[]
 === HttpRequest
 
 include::{snippets}/review-delete/http-request.adoc[]
+include::{snippets}/review-delete/path-parameters.adoc[]
 
 === HttpResponse
 
@@ -47,6 +48,7 @@ include::{snippets}/review-delete/response-fields.adoc[]
 
 include::{snippets}/review-update/http-request.adoc[]
 include::{snippets}/review-update/request-fields.adoc[]
+include::{snippets}/review-update/path-parameters.adoc[]
 
 === HttpResponse
 
@@ -54,15 +56,16 @@ include::{snippets}/review-update/http-response.adoc[]
 include::{snippets}/review-update/response-fields.adoc[]
 
 [[Review-Get-All]]
-== 전체 리뷰 조회
+== 리뷰 전체 조회
 
 전체 리뷰를 조회하는 API 입니다.
 
-* sortBy로 최신순, 별점순 정렬 가능 (createdAt  /  rating)
+* sortBy 값이 없으면 createdAt(최신순) 기준으로 정렬됩니다.
 
 === HttpRequest
 
 include::{snippets}/reviews-get-all/http-request.adoc[]
+include::{snippets}/reviews-get-all/query-parameters.adoc[]
 
 === HttpResponse
 
@@ -74,11 +77,12 @@ include::{snippets}/reviews-get-all/response-fields.adoc[]
 
 부트캠프별 리뷰를 조회하는 API 입니다.
 
-* sortBy로 최신순, 별점순 정렬 가능 (createdAt  /  rating)
+* sortBy 값이 없으면 createdAt(최신순) 기준으로 정렬됩니다.
 
 === HttpRequest
 
 include::{snippets}/reviews-get-bootcamp/http-request.adoc[]
+include::{snippets}/reviews-get-bootcamp/query-parameters.adoc[]
 
 === HttpResponse
 
@@ -88,7 +92,7 @@ include::{snippets}/reviews-get-bootcamp/response-fields.adoc[]
 [[Review-Get-Summary]]
 == 부트캠프별 리뷰 요약
 
-부트캠프별 리뷰를 요악하는 API 입니다.
+부트캠프별 요악을 조회하는 API 입니다.
 
 === HttpRequest
 
@@ -99,6 +103,20 @@ include::{snippets}/reviews-get-summary/http-request.adoc[]
 include::{snippets}/reviews-get-summary/http-response.adoc[]
 include::{snippets}/reviews-get-summary/response-fields.adoc[]
 
+[[Review-Get-TagGraph]]
+== 부트캠프별 태그 그래프
+
+부트캠프별 태그 그래프를 조회하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/reviews-get-tag-graph/http-request.adoc[]
+include::{snippets}/reviews-get-tag-graph/query-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/reviews-get-tag-graph/http-response.adoc[]
+include::{snippets}/reviews-get-tag-graph/response-fields.adoc[]
 
 
 

--- a/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fasttime/domain/member/repository/MemberRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
 
     Optional<Member> findByNickname(String nickname);
 
@@ -19,11 +17,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     void deleteByDeletedAtBefore(LocalDateTime dateTime);
 
-
+    boolean existsByBootcamp(String bootcamp);
 
     @Query("SELECT m FROM Member m WHERE m.email = :email AND m.deletedAt > :dateTime")
     Optional<Member> findSoftDeletedByEmail(@Param("email") String email,
         @Param("dateTime") LocalDateTime dateTime);
-
-
 }

--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.fasttime.domain.review.controller;
 
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
+import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.ResponseDTO;
@@ -72,5 +73,11 @@ public class ReviewController {
 
         List<ReviewResponseDTO> reviews = reviewService.getReviewsByBootcamp(bootcamp, sortBy);
         return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
+    }
+
+    @GetMapping("/by-bootcamp/summary")
+    public ResponseEntity<ResponseDTO<List<BootcampReviewSummaryDTO>>> getBootcampReviewSummaries() {
+        List<BootcampReviewSummaryDTO> summaries = reviewService.getBootcampReviewSummaries();
+        return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, summaries));
     }
 }

--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -59,7 +59,7 @@ public class ReviewController {
             ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, responseDTO));
     }
 
-    @GetMapping("/all")
+    @GetMapping
     public ResponseEntity<ResponseDTO<List<ReviewResponseDTO>>> getReviews(
         @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
         List<ReviewResponseDTO> reviews = reviewService.getSortedReviews(sortBy);

--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -5,15 +5,18 @@ import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.ResponseDTO;
 import com.fasttime.global.util.SecurityUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -53,5 +56,12 @@ public class ReviewController {
             requestDTO, memberId);
         return ResponseEntity.ok(
             ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, responseDTO));
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<ResponseDTO<List<ReviewResponseDTO>>> getReviews(
+        @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
+        List<ReviewResponseDTO> reviews = reviewService.getSortedReviews(sortBy);
+        return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
     }
 }

--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -61,17 +61,11 @@ public class ReviewController {
 
     @GetMapping
     public ResponseEntity<ResponseDTO<List<ReviewResponseDTO>>> getReviews(
-        @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
-        List<ReviewResponseDTO> reviews = reviewService.getSortedReviews(sortBy);
-        return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
-    }
-
-    @GetMapping("/by-bootcamp")
-    public ResponseEntity<ResponseDTO<List<ReviewResponseDTO>>> getReviewsByBootcamp(
-        @RequestParam String bootcamp,
+        @RequestParam(required = false) String bootcamp,
         @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
 
-        List<ReviewResponseDTO> reviews = reviewService.getReviewsByBootcamp(bootcamp, sortBy);
+        List<ReviewResponseDTO> reviews = reviewService.getSortedReviews(sortBy, bootcamp);
+
         return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
     }
 

--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.fasttime.domain.review.controller;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
 import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
+import com.fasttime.domain.review.dto.response.TagSummaryDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.ResponseDTO;
 import com.fasttime.global.util.SecurityUtil;
@@ -69,9 +70,16 @@ public class ReviewController {
         return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
     }
 
-    @GetMapping("/by-bootcamp/summary")
+    @GetMapping("/summary")
     public ResponseEntity<ResponseDTO<List<BootcampReviewSummaryDTO>>> getBootcampReviewSummaries() {
         List<BootcampReviewSummaryDTO> summaries = reviewService.getBootcampReviewSummaries();
         return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, summaries));
+    }
+
+    @GetMapping("/tag-graph")
+    public ResponseEntity<ResponseDTO<TagSummaryDTO>> getTagCountsByBootcamp(
+        @RequestParam String bootcamp) {
+        TagSummaryDTO tagData = reviewService.getBootcampTagData(bootcamp);
+        return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, tagData));
     }
 }

--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -64,4 +64,13 @@ public class ReviewController {
         List<ReviewResponseDTO> reviews = reviewService.getSortedReviews(sortBy);
         return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
     }
+
+    @GetMapping("/by-bootcamp")
+    public ResponseEntity<ResponseDTO<List<ReviewResponseDTO>>> getReviewsByBootcamp(
+        @RequestParam String bootcamp,
+        @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
+
+        List<ReviewResponseDTO> reviews = reviewService.getReviewsByBootcamp(bootcamp, sortBy);
+        return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, reviews));
+    }
 }

--- a/src/main/java/com/fasttime/domain/review/dto/response/BootcampReviewSummaryDTO.java
+++ b/src/main/java/com/fasttime/domain/review/dto/response/BootcampReviewSummaryDTO.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.review.dto.response;
+
+import java.util.Map;
+
+public record BootcampReviewSummaryDTO(
+    String bootcamp,
+    double averageRating,
+    int totalReviews,
+    int totalTags,
+    Map<Long, Long> tagCounts
+) {}

--- a/src/main/java/com/fasttime/domain/review/dto/response/BootcampReviewSummaryDTO.java
+++ b/src/main/java/com/fasttime/domain/review/dto/response/BootcampReviewSummaryDTO.java
@@ -1,11 +1,7 @@
 package com.fasttime.domain.review.dto.response;
 
-import java.util.Map;
-
 public record BootcampReviewSummaryDTO(
     String bootcamp,
     double averageRating,
-    int totalReviews,
-    int totalTags,
-    Map<Long, Long> tagCounts
+    int totalReviews
 ) {}

--- a/src/main/java/com/fasttime/domain/review/dto/response/TagSummaryDTO.java
+++ b/src/main/java/com/fasttime/domain/review/dto/response/TagSummaryDTO.java
@@ -1,0 +1,10 @@
+package com.fasttime.domain.review.dto.response;
+
+import java.util.Map;
+
+public record TagSummaryDTO(
+    int totalTags,
+    Map<Long, Long> tagCounts
+) {
+
+}

--- a/src/main/java/com/fasttime/domain/review/entity/Review.java
+++ b/src/main/java/com/fasttime/domain/review/entity/Review.java
@@ -2,6 +2,7 @@ package com.fasttime.domain.review.entity;
 
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.global.common.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -36,7 +38,8 @@ public class Review extends BaseTimeEntity {
 
     private String content;
 
-    @OneToMany(mappedBy = "review")
+    @Builder.Default
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private Set<ReviewTag> reviewTags = new HashSet<>();
 
     @JoinColumn(name = "member_id")
@@ -47,7 +50,7 @@ public class Review extends BaseTimeEntity {
         this.reviewTags = reviewTags;
     }
 
-    public void updateReviewDetails(String title, int rating, String content){
+    public void updateReviewDetails(String title, int rating, String content) {
         this.title = title;
         this.rating = rating;
         this.content = content;

--- a/src/main/java/com/fasttime/domain/review/entity/ReviewTag.java
+++ b/src/main/java/com/fasttime/domain/review/entity/ReviewTag.java
@@ -27,7 +27,4 @@ public class ReviewTag {
     @ManyToOne
     @JoinColumn(name = "tag_id")
     private Tag tag;
-
-    private boolean isGoodTag;
-
 }

--- a/src/main/java/com/fasttime/domain/review/entity/ReviewTag.java
+++ b/src/main/java/com/fasttime/domain/review/entity/ReviewTag.java
@@ -28,4 +28,6 @@ public class ReviewTag {
     @JoinColumn(name = "tag_id")
     private Tag tag;
 
+    private boolean isGoodTag;
+
 }

--- a/src/main/java/com/fasttime/domain/review/entity/Tag.java
+++ b/src/main/java/com/fasttime/domain/review/entity/Tag.java
@@ -25,6 +25,8 @@ public class Tag {
 
     private String content;
 
+    private boolean isGoodTag;
+
     public static Tag create(String content) {
         return new Tag(content);
     }

--- a/src/main/java/com/fasttime/domain/review/exception/BootCampNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/review/exception/BootCampNotFoundException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.review.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class BootCampNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.BOOTCAMP_NOT_FOUND;
+
+    public BootCampNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
@@ -4,9 +4,20 @@ import com.fasttime.domain.review.entity.Review;
 import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
     Review findByMemberId(Long memberId);
+
+    @Query("SELECT DISTINCT r.bootcamp FROM Review r")
+    List<String> findAllBootcamps();
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.bootcamp = :bootcamp")
+    int countByBootcamp(String bootcamp);
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.bootcamp = :bootcamp")
+    double findAverageRatingByBootcamp(String bootcamp);
 
     List<Review> findByBootcamp(String bootcamp, Sort sort);
 }

--- a/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,12 @@
 package com.fasttime.domain.review.repository;
 
 import com.fasttime.domain.review.entity.Review;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Review findByMemberId(Long memberId);
+
+    List<Review> findByBootcamp(String bootcamp, Sort sort);
 }

--- a/src/main/java/com/fasttime/domain/review/repository/ReviewTagRepository.java
+++ b/src/main/java/com/fasttime/domain/review/repository/ReviewTagRepository.java
@@ -1,0 +1,9 @@
+package com.fasttime.domain.review.repository;
+
+import com.fasttime.domain.review.entity.Review;
+import com.fasttime.domain.review.entity.ReviewTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
+    void deleteByReview(Review review);
+}

--- a/src/main/java/com/fasttime/domain/review/repository/ReviewTagRepository.java
+++ b/src/main/java/com/fasttime/domain/review/repository/ReviewTagRepository.java
@@ -2,8 +2,17 @@ package com.fasttime.domain.review.repository;
 
 import com.fasttime.domain.review.entity.Review;
 import com.fasttime.domain.review.entity.ReviewTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
+
     void deleteByReview(Review review);
+
+    @Query("SELECT COUNT(rt) FROM ReviewTag rt JOIN rt.review r WHERE r.bootcamp = :bootcamp")
+    int countByBootcamp(String bootcamp);
+
+    @Query("SELECT rt.tag.id, COUNT(rt) FROM ReviewTag rt JOIN rt.review r WHERE r.bootcamp = :bootcamp GROUP BY rt.tag.id")
+    List<Object[]> countTagsByBootcampGroupedByTagId(String bootcamp);
 }

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -51,8 +51,7 @@ public class ReviewService {
         if (existingReview != null) {
             if (existingReview.isDeleted()) {
                 reviewTagRepository.deleteByReview(existingReview);
-                updateReviewDetails(existingReview, requestDTO);
-                updateReviewTags(existingReview, requestDTO);
+                updateReview(existingReview, requestDTO);
                 existingReview.restore();
                 return reviewRepository.save(existingReview);
             } else {
@@ -105,9 +104,13 @@ public class ReviewService {
         }
         reviewTagRepository.deleteByReview(review);
 
+        updateReview(review, requestDTO);
+        return reviewRepository.save(review);
+    }
+
+    private void updateReview(Review review, ReviewRequestDTO requestDTO) {
         updateReviewDetails(review, requestDTO);
         updateReviewTags(review, requestDTO);
-        return reviewRepository.save(review);
     }
 
     private void updateReviewDetails(Review review, ReviewRequestDTO requestDTO) {

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -159,4 +159,12 @@ public class ReviewService {
             .map(Tag::getContent)
             .collect(Collectors.toSet());
     }
+
+    public List<ReviewResponseDTO> getReviewsByBootcamp(String bootcamp, String sortBy) {
+        Sort sort = sortBy.equals("rating") ? Sort.by("rating").descending() : Sort.by("createdAt").descending();
+        List<Review> reviews = reviewRepository.findByBootcamp(bootcamp, sort);
+        return reviews.stream()
+            .map(this::convertToReviewResponseDTO)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.member.exception.MemberNotFoundException;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
+import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.entity.Review;
 import com.fasttime.domain.review.entity.ReviewTag;
@@ -16,8 +17,11 @@ import com.fasttime.domain.review.exception.UnauthorizedAccessException;
 import com.fasttime.domain.review.repository.ReviewRepository;
 import com.fasttime.domain.review.repository.ReviewTagRepository;
 import com.fasttime.domain.review.repository.TagRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -166,5 +170,27 @@ public class ReviewService {
         return reviews.stream()
             .map(this::convertToReviewResponseDTO)
             .collect(Collectors.toList());
+    }
+
+    public List<BootcampReviewSummaryDTO> getBootcampReviewSummaries() {
+        List<String> bootcamps = reviewRepository.findAllBootcamps();
+        List<BootcampReviewSummaryDTO> summaries = new ArrayList<>();
+
+        for (String bootcamp : bootcamps) {
+            double averageRating = reviewRepository.findAverageRatingByBootcamp(bootcamp);
+            int totalReviews = reviewRepository.countByBootcamp(bootcamp);
+            int totalTags = reviewTagRepository.countByBootcamp(bootcamp);
+
+            List<Object[]> tagCountsArray = reviewTagRepository.countTagsByBootcampGroupedByTagId(bootcamp);
+            Map<Long, Long> tagCounts = new HashMap<>();
+            for (Object[] count : tagCountsArray) {
+                Long tagId = (Long) count[0];
+                Long totalCount = (Long) count[1];
+                tagCounts.put(tagId, totalCount);
+            }
+
+            summaries.add(new BootcampReviewSummaryDTO(bootcamp, averageRating, totalReviews, totalTags, tagCounts));
+        }
+        return summaries;
     }
 }

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -136,11 +136,16 @@ public class ReviewService {
         return ReviewResponseDTO.of(updatedReview, goodTagContents, badTagContents);
     }
 
-    @Transactional(readOnly = true)
-    public List<ReviewResponseDTO> getSortedReviews(String sortBy) {
+    public List<ReviewResponseDTO> getSortedReviews(String sortBy, String bootcamp) {
         Sort sort = sortBy.equals("rating") ? Sort.by("rating").descending()
             : Sort.by("createdAt").descending();
-        List<Review> reviews = reviewRepository.findAll(sort);
+
+        List<Review> reviews;
+        if (bootcamp != null && !bootcamp.isEmpty()) {
+            reviews = reviewRepository.findByBootcamp(bootcamp, sort);
+        } else {
+            reviews = reviewRepository.findAll(sort);
+        }
 
         return reviews.stream()
             .map(this::convertToReviewResponseDTO)

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
 import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
+import com.fasttime.domain.review.dto.response.TagSummaryDTO;
 import com.fasttime.domain.review.entity.Review;
 import com.fasttime.domain.review.entity.ReviewTag;
 import com.fasttime.domain.review.entity.Tag;
@@ -185,21 +186,25 @@ public class ReviewService {
         for (String bootcamp : bootcamps) {
             double averageRating = reviewRepository.findAverageRatingByBootcamp(bootcamp);
             int totalReviews = reviewRepository.countByBootcamp(bootcamp);
-            int totalTags = reviewTagRepository.countByBootcamp(bootcamp);
 
-            List<Object[]> tagCountsArray = reviewTagRepository.countTagsByBootcampGroupedByTagId(
-                bootcamp);
-            Map<Long, Long> tagCounts = new HashMap<>();
-            for (Object[] count : tagCountsArray) {
-                Long tagId = (Long) count[0];
-                Long totalCount = (Long) count[1];
-                tagCounts.put(tagId, totalCount);
-            }
-
-            summaries.add(
-                new BootcampReviewSummaryDTO(bootcamp, averageRating, totalReviews, totalTags,
-                    tagCounts));
+            summaries.add(new BootcampReviewSummaryDTO(bootcamp, averageRating, totalReviews));
         }
         return summaries;
+    }
+
+    public TagSummaryDTO getBootcampTagData(String bootcamp) {
+        List<Object[]> tagCountsArray = reviewTagRepository.countTagsByBootcampGroupedByTagId(
+            bootcamp);
+        Map<Long, Long> tagCounts = new HashMap<>();
+        int totalTags = 0;
+
+        for (Object[] count : tagCountsArray) {
+            Long tagId = (Long) count[0];
+            Long countValue = (Long) count[1];
+            tagCounts.put(tagId, countValue);
+            totalTags += countValue;
+        }
+
+        return new TagSummaryDTO(totalTags, tagCounts);
     }
 }

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -109,12 +109,8 @@ public class ReviewService {
     }
 
     private void updateReview(Review review, ReviewRequestDTO requestDTO) {
-        updateReviewDetails(review, requestDTO);
-        updateReviewTags(review, requestDTO);
-    }
-
-    private void updateReviewDetails(Review review, ReviewRequestDTO requestDTO) {
         review.updateReviewDetails(requestDTO.title(), requestDTO.rating(), requestDTO.content());
+        updateReviewTags(review, requestDTO);
     }
 
     private void updateReviewTags(Review review, ReviewRequestDTO requestDTO) {
@@ -171,15 +167,6 @@ public class ReviewService {
             .map(ReviewTag::getTag)
             .map(Tag::getContent)
             .collect(Collectors.toSet());
-    }
-
-    public List<ReviewResponseDTO> getReviewsByBootcamp(String bootcamp, String sortBy) {
-        Sort sort = sortBy.equals("rating") ? Sort.by("rating").descending()
-            : Sort.by("createdAt").descending();
-        List<Review> reviews = reviewRepository.findByBootcamp(bootcamp, sort);
-        return reviews.stream()
-            .map(this::convertToReviewResponseDTO)
-            .collect(Collectors.toList());
     }
 
     public List<BootcampReviewSummaryDTO> getBootcampReviewSummaries() {

--- a/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
@@ -44,6 +44,7 @@ public class SpringSecurityConfig {
         "/api/live/**",
         "/api/dashboards/**",
         "/actuator/**",
+        "/api/v2/reviews/all",
     };
     private static final String[] GRAFANA_WHITE_LIST = {
         "/public/**",

--- a/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
@@ -45,6 +45,7 @@ public class SpringSecurityConfig {
         "/api/dashboards/**",
         "/actuator/**",
         "/api/v2/reviews/all",
+        "/api/v2/reviews/by-bootcamp",
     };
     private static final String[] GRAFANA_WHITE_LIST = {
         "/public/**",

--- a/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
@@ -45,7 +45,7 @@ public class SpringSecurityConfig {
         "/api/dashboards/**",
         "/actuator/**",
         "/api/v2/reviews/all",
-        "/api/v2/reviews/by-bootcamp",
+        "/api/v2/reviews/by-bootcamp/**",
     };
     private static final String[] GRAFANA_WHITE_LIST = {
         "/public/**",

--- a/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
@@ -44,7 +44,6 @@ public class SpringSecurityConfig {
         "/api/live/**",
         "/api/dashboards/**",
         "/actuator/**",
-        "/api/v2/reviews/by-bootcamp/**",
     };
     private static final String[] GRAFANA_WHITE_LIST = {
         "/public/**",
@@ -62,7 +61,7 @@ public class SpringSecurityConfig {
             .authorizeHttpRequests(requests -> requests
                 .requestMatchers(PERMIT_URL_ARRAY).permitAll()
                 .requestMatchers(GRAFANA_WHITE_LIST).permitAll()
-                .requestMatchers(HttpMethod.GET, "api/v1/article", "api/v2/articles", "api/v2/reviews").permitAll()
+                .requestMatchers(HttpMethod.GET, "api/v1/article", "api/v2/articles", "api/v2/reviews/**").permitAll()
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .anyRequest().authenticated())

--- a/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/fasttime/global/config/SpringSecurityConfig.java
@@ -44,7 +44,6 @@ public class SpringSecurityConfig {
         "/api/live/**",
         "/api/dashboards/**",
         "/actuator/**",
-        "/api/v2/reviews/all",
         "/api/v2/reviews/by-bootcamp/**",
     };
     private static final String[] GRAFANA_WHITE_LIST = {
@@ -63,7 +62,7 @@ public class SpringSecurityConfig {
             .authorizeHttpRequests(requests -> requests
                 .requestMatchers(PERMIT_URL_ARRAY).permitAll()
                 .requestMatchers(GRAFANA_WHITE_LIST).permitAll()
-                .requestMatchers(HttpMethod.GET, "api/v1/article", "api/v2/articles").permitAll()
+                .requestMatchers(HttpMethod.GET, "api/v1/article", "api/v2/articles", "api/v2/reviews").permitAll()
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .anyRequest().authenticated())

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     // REVIEW
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 태그입니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다."),
+    BOOTCAMP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 부트캠프입니다."),
     ALREADY_DELETED_THIS_REVIEW(HttpStatus.BAD_REQUEST, "이미 삭제한 리뷰입니다."),
     HAS_NO_PERMISSION_WITH_THIS_REVIEW(HttpStatus.UNAUTHORIZED, "리뷰 작성/삭제 권한이 없습니다."),
     REVIEW_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성했습니다."),

--- a/src/main/resources/db/migration/V15__Add_Column_reviewtag_table.sql
+++ b/src/main/resources/db/migration/V15__Add_Column_reviewtag_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE review_tag
+    ADD COLUMN isGoodTag BOOLEAN;

--- a/src/main/resources/db/migration/V15__Add_Column_tag_table.sql
+++ b/src/main/resources/db/migration/V15__Add_Column_tag_table.sql
@@ -1,2 +1,2 @@
-ALTER TABLE review_tag
+ALTER TABLE tag
     ADD COLUMN isGoodTag BOOLEAN;

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -2,13 +2,15 @@ package com.fasttime.domain.review.docs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.review.controller.ReviewController;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
@@ -20,7 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 
 class ReviewControllerDocsTest extends RestDocsSupport {
 
@@ -38,7 +40,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
 
         ReviewRequestDTO requestDto = new ReviewRequestDTO("test 부트캠프 리뷰", Set.of(1L, 2L), Set.of(3L, 4L), 5, "뭐야");
 
-        // 응답 DTO 모킹
+
         when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class), anyLong()))
             .thenReturn(new ReviewResponseDTO(7L, "다른 부트캠프", "test 부트캠프 리뷰", Set.of("친절해요", "강의가 좋아요"), Set.of("불친절해요", "피드백이 느려요"), 5, "뭐야"));
 
@@ -66,6 +68,27 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.badtags").type(JsonFieldType.ARRAY).description("나빠요 태그 목록"),
                     fieldWithPath("data.rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
                     fieldWithPath("data.content").type(JsonFieldType.STRING).description("리뷰 내용")
+                )
+            ));
+    }
+
+    @DisplayName("리뷰 삭제 API 문서화")
+    @Test
+    void deleteReview() throws Exception {
+
+        doNothing().when(reviewService).deleteReview(anyLong(), anyLong());
+
+
+        this.mockMvc.perform(delete("/api/v2/reviews/{reviewId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document("reviews-delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (null)")
                 )
             ));
     }

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -103,18 +103,16 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     @DisplayName("리뷰 수정 API 문서화")
     @Test
     void updateReview() throws Exception {
-        // 요청 DTO 준비
+
         ReviewRequestDTO requestDto = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(2L),
             Set.of(18L, 19L), 5, "수정된 리뷰 내용");
 
-        // 응답 DTO 모킹
         ReviewResponseDTO responseDTO = new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "수정된 리뷰 제목",
             Set.of("강의가 좋아요"), Set.of("부족한 혜택", "오프라인"), 5, "수정된 리뷰 내용");
 
         when(reviewService.updateAndReturnReviewResponse(anyLong(), any(ReviewRequestDTO.class),
             anyLong())).thenReturn(responseDTO);
 
-        // 리뷰 수정 요청 실행
         this.mockMvc.perform(put("/api/v2/reviews/{reviewId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(requestDto)))
@@ -150,8 +148,10 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     @Test
     void getReviews() throws Exception {
         List<ReviewResponseDTO> reviews = List.of(
-            new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "리뷰 제목 1", Set.of("친절해요"), Set.of("불친절해요"), 5, "리뷰 내용 1"),
-            new ReviewResponseDTO(2L, "다른 부트캠프", "리뷰 제목 2", Set.of("강의가 좋아요"), Set.of("피드백이 느려요"), 4, "리뷰 내용 2")
+            new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "리뷰 제목 1", Set.of("친절해요"), Set.of("불친절해요"),
+                5, "리뷰 내용 1"),
+            new ReviewResponseDTO(2L, "다른 부트캠프", "리뷰 제목 2", Set.of("강의가 좋아요"), Set.of("피드백이 느려요"),
+                4, "리뷰 내용 2")
         );
 
         when(reviewService.getSortedReviews(anyString())).thenReturn(reviews);
@@ -165,10 +165,49 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                     fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("리뷰 ID"),
-                    fieldWithPath("data[].bootcamp").type(JsonFieldType.STRING).description("부트캠프 이름"),
+                    fieldWithPath("data[].bootcamp").type(JsonFieldType.STRING)
+                        .description("부트캠프 이름"),
                     fieldWithPath("data[].title").type(JsonFieldType.STRING).description("리뷰 제목"),
-                    fieldWithPath("data[].goodtags").type(JsonFieldType.ARRAY).description("좋아요 태그 목록"),
-                    fieldWithPath("data[].badtags").type(JsonFieldType.ARRAY).description("나빠요 태그 목록"),
+                    fieldWithPath("data[].goodtags").type(JsonFieldType.ARRAY)
+                        .description("좋아요 태그 목록"),
+                    fieldWithPath("data[].badtags").type(JsonFieldType.ARRAY)
+                        .description("나빠요 태그 목록"),
+                    fieldWithPath("data[].rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+                    fieldWithPath("data[].content").type(JsonFieldType.STRING).description("리뷰 내용")
+                )
+            ));
+    }
+
+    @DisplayName("부트캠프별 리뷰 조회 API 문서화")
+    @Test
+    void getReviewsByBootcamp() throws Exception {
+        List<ReviewResponseDTO> reviews = List.of(
+            new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "리뷰 제목 1", Set.of("친절해요"), Set.of("불친절해요"),
+                5, "리뷰 내용 1"),
+            new ReviewResponseDTO(2L, "패스트캠퍼스X야놀자 부트캠프", "리뷰 제목 2", Set.of("강의가 좋아요"),
+                Set.of("피드백이 느려요"), 4, "리뷰 내용 2")
+        );
+
+        when(reviewService.getReviewsByBootcamp(anyString(), anyString())).thenReturn(reviews);
+
+        mockMvc.perform(get("/api/v2/reviews/by-bootcamp")
+                .param("bootcamp", "패스트캠퍼스X야놀자 부트캠프")
+                .param("sortBy", "rating"))
+            .andExpect(status().isOk())
+            .andDo(document("reviews-get-bootcamp",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("리뷰 ID"),
+                    fieldWithPath("data[].bootcamp").type(JsonFieldType.STRING)
+                        .description("부트캠프 이름"),
+                    fieldWithPath("data[].title").type(JsonFieldType.STRING).description("리뷰 제목"),
+                    fieldWithPath("data[].goodtags").type(JsonFieldType.ARRAY)
+                        .description("좋아요 태그 목록"),
+                    fieldWithPath("data[].badtags").type(JsonFieldType.ARRAY)
+                        .description("나빠요 태그 목록"),
                     fieldWithPath("data[].rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
                     fieldWithPath("data[].content").type(JsonFieldType.STRING).description("리뷰 내용")
                 )

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -18,10 +18,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.review.controller.ReviewController;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
+import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.SecurityUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -210,6 +212,41 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                         .description("나빠요 태그 목록"),
                     fieldWithPath("data[].rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
                     fieldWithPath("data[].content").type(JsonFieldType.STRING).description("리뷰 내용")
+                )
+            ));
+    }
+
+    @DisplayName("부트캠프별 리뷰 요약 조회 API 문서화")
+    @Test
+    void getBootcampReviewSummaries() throws Exception {
+        List<BootcampReviewSummaryDTO> summaries = List.of(
+            new BootcampReviewSummaryDTO("야놀자x패스트캠퍼스 부트캠프", 2.0, 1, 2, Map.of(1L, 1L, 3L, 1L)),
+            new BootcampReviewSummaryDTO("다른 부트캠프", 1.5, 2, 7,
+                Map.of(1L, 2L, 2L, 2L, 3L, 2L, 4L, 1L))
+        );
+
+        when(reviewService.getBootcampReviewSummaries()).thenReturn(summaries);
+
+        mockMvc.perform(get("/api/v2/reviews/by-bootcamp/summary")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document("reviews-get-summary",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data[].bootcamp").type(JsonFieldType.STRING)
+                        .description("부트캠프 이름"),
+                    fieldWithPath("data[].averageRating").type(JsonFieldType.NUMBER)
+                        .description("평균 평점"),
+                    fieldWithPath("data[].totalReviews").type(JsonFieldType.NUMBER)
+                        .description("총 리뷰 수"),
+                    fieldWithPath("data[].totalTags").type(JsonFieldType.NUMBER)
+                        .description("총 태그 수"),
+                    subsectionWithPath("data[].tagCounts").type(JsonFieldType.OBJECT)
+                        .description("태그별 사용 횟수")
+
                 )
             ));
     }

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -1,0 +1,72 @@
+package com.fasttime.domain.review.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasttime.docs.RestDocsSupport;
+import com.fasttime.domain.review.controller.ReviewController;
+import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
+import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
+import com.fasttime.domain.review.service.ReviewService;
+import com.fasttime.global.util.SecurityUtil;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+class ReviewControllerDocsTest extends RestDocsSupport {
+
+    private final ReviewService reviewService = mock(ReviewService.class);
+    private final SecurityUtil securityUtil = mock(SecurityUtil.class);
+
+    @Override
+    public Object initController() {
+        return new ReviewController(reviewService, securityUtil);
+    }
+
+    @DisplayName("리뷰 작성 API 문서화")
+    @Test
+    void createReview() throws Exception {
+
+        ReviewRequestDTO requestDto = new ReviewRequestDTO("test 부트캠프 리뷰", Set.of(1L, 2L), Set.of(3L, 4L), 5, "뭐야");
+
+        // 응답 DTO 모킹
+        when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class), anyLong()))
+            .thenReturn(new ReviewResponseDTO(7L, "다른 부트캠프", "test 부트캠프 리뷰", Set.of("친절해요", "강의가 좋아요"), Set.of("불친절해요", "피드백이 느려요"), 5, "뭐야"));
+
+        mockMvc.perform(post("/api/v2/reviews")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andDo(document("review-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("title").type(JsonFieldType.STRING).description("리뷰 제목"),
+                    fieldWithPath("goodtags").type(JsonFieldType.ARRAY).description("좋은 태그 ID 목록"),
+                    fieldWithPath("badtags").type(JsonFieldType.ARRAY).description("나쁜 태그 ID 목록"),
+                    fieldWithPath("rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+                    fieldWithPath("content").type(JsonFieldType.STRING).description("리뷰 내용")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리뷰 ID"),
+                    fieldWithPath("data.bootcamp").type(JsonFieldType.STRING).description("부트캠프 이름"),
+                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("리뷰 제목"),
+                    fieldWithPath("data.goodtags").type(JsonFieldType.ARRAY).description("좋아요 태그 목록"),
+                    fieldWithPath("data.badtags").type(JsonFieldType.ARRAY).description("나빠요 태그 목록"),
+                    fieldWithPath("data.rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("리뷰 내용")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -3,6 +3,8 @@ package com.fasttime.domain.review.docs;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -11,15 +13,18 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.review.controller.ReviewController;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
 import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
+import com.fasttime.domain.review.dto.response.TagSummaryDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.SecurityUtil;
 import java.util.List;
@@ -29,6 +34,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 class ReviewControllerDocsTest extends RestDocsSupport {
 
@@ -45,7 +52,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     void createReview() throws Exception {
 
         ReviewRequestDTO requestDto = new ReviewRequestDTO("패스트캠퍼스X야놀자 솔직후기", Set.of(1L, 2L),
-            Set.of(18L, 19L), 3, "전체적으로 아쉬웠습니다.");
+            Set.of(8L, 9L), 3, "전체적으로 아쉬웠습니다.");
 
         when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class), anyLong()))
             .thenReturn(new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "패스트캠퍼스X야놀자 솔직후기",
@@ -85,7 +92,6 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     @DisplayName("리뷰 삭제 API 문서화")
     @Test
     void deleteReview() throws Exception {
-
         doNothing().when(reviewService).deleteReview(anyLong(), anyLong());
 
         this.mockMvc.perform(delete("/api/v2/reviews/{reviewId}", 1L)
@@ -94,6 +100,9 @@ class ReviewControllerDocsTest extends RestDocsSupport {
             .andDo(document("review-delete",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("reviewId").description("리뷰 id")
+                ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -105,23 +114,27 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     @DisplayName("리뷰 수정 API 문서화")
     @Test
     void updateReview() throws Exception {
-
         ReviewRequestDTO requestDto = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(2L),
-            Set.of(18L, 19L), 5, "수정된 리뷰 내용");
+            Set.of(8L, 9L), 5, "수정된 리뷰 내용");
 
-        ReviewResponseDTO responseDTO = new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "수정된 리뷰 제목",
-            Set.of("강의가 좋아요"), Set.of("부족한 혜택", "오프라인"), 5, "수정된 리뷰 내용");
+        ReviewResponseDTO responseDTO = new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프",
+            "수정된 리뷰 제목", Set.of("강의가 좋아요"), Set.of("부족한 혜택", "오프라인"), 5, "수정된 리뷰 내용");
 
-        when(reviewService.updateAndReturnReviewResponse(anyLong(), any(ReviewRequestDTO.class),
-            anyLong())).thenReturn(responseDTO);
+        when(reviewService.updateAndReturnReviewResponse(eq(1L), any(ReviewRequestDTO.class),
+            anyLong()))
+            .thenReturn(responseDTO);
 
-        this.mockMvc.perform(put("/api/v2/reviews/{reviewId}", 1L)
+        mockMvc.perform(put("/api/v2/reviews/{reviewId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(requestDto)))
             .andExpect(status().isOk())
             .andDo(document("review-update",
+
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("reviewId").description("리뷰 id")
+                ),
                 requestFields(
                     fieldWithPath("title").type(JsonFieldType.STRING).description("리뷰 제목"),
                     fieldWithPath("goodtags").type(JsonFieldType.ARRAY).description("좋은 태그 ID 목록"),
@@ -156,13 +169,18 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                 4, "리뷰 내용 2")
         );
 
-        when(reviewService.getSortedReviews(anyString())).thenReturn(reviews);
+        when(reviewService.getSortedReviews(anyString(), isNull())).thenReturn(reviews);
 
-        mockMvc.perform(get("/api/v2/reviews/all"))
+        mockMvc.perform(get("/api/v2/reviews")
+                .queryParam("sortBy", "rating"))
             .andExpect(status().isOk())
             .andDo(document("reviews-get-all",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                queryParameters(
+                    parameterWithName("sortBy").description("기본값: 'createdAt' 옵션: 'rating'")
+                        .optional()
+                ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -190,15 +208,23 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                 Set.of("피드백이 느려요"), 4, "리뷰 내용 2")
         );
 
-        when(reviewService.getReviewsByBootcamp(anyString(), anyString())).thenReturn(reviews);
+        when(reviewService.getSortedReviews(eq("rating"), eq("패스트캠퍼스X야놀자 부트캠프")))
+            .thenReturn(reviews);
 
-        mockMvc.perform(get("/api/v2/reviews/by-bootcamp")
-                .param("bootcamp", "패스트캠퍼스X야놀자 부트캠프")
-                .param("sortBy", "rating"))
+        mockMvc.perform(get("/api/v2/reviews")
+                .queryParam("bootcamp", "패스트캠퍼스X야놀자 부트캠프")
+                .queryParam("sortBy", "rating"))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data[0].id").exists())
             .andDo(document("reviews-get-bootcamp",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                queryParameters(
+                    parameterWithName("bootcamp").description("부트캠프 이름").optional(),
+                    parameterWithName("sortBy").description("기본값: 'createdAt' 옵션: 'rating'")
+                        .optional()
+                ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -220,14 +246,13 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     @Test
     void getBootcampReviewSummaries() throws Exception {
         List<BootcampReviewSummaryDTO> summaries = List.of(
-            new BootcampReviewSummaryDTO("야놀자x패스트캠퍼스 부트캠프", 2.0, 1, 2, Map.of(1L, 1L, 3L, 1L)),
-            new BootcampReviewSummaryDTO("다른 부트캠프", 1.5, 2, 7,
-                Map.of(1L, 2L, 2L, 2L, 3L, 2L, 4L, 1L))
+            new BootcampReviewSummaryDTO("야놀자x패스트캠퍼스 부트캠프", 3.0, 7),
+            new BootcampReviewSummaryDTO("다른 부트캠프", 4.5, 2)
         );
 
         when(reviewService.getBootcampReviewSummaries()).thenReturn(summaries);
 
-        mockMvc.perform(get("/api/v2/reviews/by-bootcamp/summary")
+        mockMvc.perform(get("/api/v2/reviews/summary")
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andDo(document("reviews-get-summary",
@@ -241,12 +266,36 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data[].averageRating").type(JsonFieldType.NUMBER)
                         .description("평균 평점"),
                     fieldWithPath("data[].totalReviews").type(JsonFieldType.NUMBER)
-                        .description("총 리뷰 수"),
-                    fieldWithPath("data[].totalTags").type(JsonFieldType.NUMBER)
-                        .description("총 태그 수"),
-                    subsectionWithPath("data[].tagCounts").type(JsonFieldType.OBJECT)
-                        .description("태그별 사용 횟수")
+                        .description("총 리뷰 수")
+                )
+            ));
+    }
 
+    @DisplayName("부트캠프별 태그 통계 조회 API 문서화")
+    @Test
+    void getTagCountsByBootcamp() throws Exception {
+        TagSummaryDTO tagSummary = new TagSummaryDTO(10, Map.of(1L, 5L, 2L, 5L));
+
+        when(reviewService.getBootcampTagData(eq("패스트캠퍼스X야놀자 부트캠프"))).thenReturn(tagSummary);
+
+        mockMvc.perform(get("/api/v2/reviews/tag-graph")
+                .queryParam("bootcamp", "패스트캠퍼스X야놀자 부트캠프"))
+            .andExpect(status().isOk())
+            .andDo(document("reviews-get-tag-graph",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                queryParameters(
+                    parameterWithName("bootcamp").description("부트캠프 이름")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data.totalTags").type(JsonFieldType.NUMBER)
+                        .description("총 태그 수"),
+                    fieldWithPath("data.tagCounts").type(JsonFieldType.OBJECT)
+                        .description("태그별 사용 횟수"),
+                    fieldWithPath("data.tagCounts.*").type(JsonFieldType.NUMBER)
+                        .description("개별 태그별 사용 횟수")
                 )
             ));
     }

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -9,8 +9,10 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import com.fasttime.docs.RestDocsSupport;
 import com.fasttime.domain.review.controller.ReviewController;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
@@ -38,11 +40,12 @@ class ReviewControllerDocsTest extends RestDocsSupport {
     @Test
     void createReview() throws Exception {
 
-        ReviewRequestDTO requestDto = new ReviewRequestDTO("test 부트캠프 리뷰", Set.of(1L, 2L), Set.of(3L, 4L), 5, "뭐야");
-
+        ReviewRequestDTO requestDto = new ReviewRequestDTO("패스트캠퍼스X야놀자 솔직후기", Set.of(1L, 2L),
+            Set.of(18L, 19L), 3, "전체적으로 아쉬웠습니다.");
 
         when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class), anyLong()))
-            .thenReturn(new ReviewResponseDTO(7L, "다른 부트캠프", "test 부트캠프 리뷰", Set.of("친절해요", "강의가 좋아요"), Set.of("불친절해요", "피드백이 느려요"), 5, "뭐야"));
+            .thenReturn(new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "패스트캠퍼스X야놀자 솔직후기",
+                Set.of("체계적인 커리큘럼", "퀄리티 있는 강의"), Set.of("부족한 혜택", "오프라인"), 3, "전체적으로 아쉬웠습니다."));
 
         mockMvc.perform(post("/api/v2/reviews")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -62,10 +65,13 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                     fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리뷰 ID"),
-                    fieldWithPath("data.bootcamp").type(JsonFieldType.STRING).description("부트캠프 이름"),
+                    fieldWithPath("data.bootcamp").type(JsonFieldType.STRING)
+                        .description("부트캠프 이름"),
                     fieldWithPath("data.title").type(JsonFieldType.STRING).description("리뷰 제목"),
-                    fieldWithPath("data.goodtags").type(JsonFieldType.ARRAY).description("좋아요 태그 목록"),
-                    fieldWithPath("data.badtags").type(JsonFieldType.ARRAY).description("나빠요 태그 목록"),
+                    fieldWithPath("data.goodtags").type(JsonFieldType.ARRAY)
+                        .description("좋아요 태그 목록"),
+                    fieldWithPath("data.badtags").type(JsonFieldType.ARRAY)
+                        .description("나빠요 태그 목록"),
                     fieldWithPath("data.rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
                     fieldWithPath("data.content").type(JsonFieldType.STRING).description("리뷰 내용")
                 )
@@ -78,17 +84,62 @@ class ReviewControllerDocsTest extends RestDocsSupport {
 
         doNothing().when(reviewService).deleteReview(anyLong(), anyLong());
 
-
         this.mockMvc.perform(delete("/api/v2/reviews/{reviewId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
-            .andDo(document("reviews-delete",
+            .andDo(document("review-delete",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                     fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (null)")
+                )
+            ));
+    }
+
+    @DisplayName("리뷰 수정 API 문서화")
+    @Test
+    void updateReview() throws Exception {
+        // 요청 DTO 준비
+        ReviewRequestDTO requestDto = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(2L),
+            Set.of(18L, 19L), 5, "수정된 리뷰 내용");
+
+        // 응답 DTO 모킹
+        ReviewResponseDTO responseDTO = new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "수정된 리뷰 제목",
+            Set.of("강의가 좋아요"), Set.of("부족한 혜택", "오프라인"), 5, "수정된 리뷰 내용");
+
+        when(reviewService.updateAndReturnReviewResponse(anyLong(), any(ReviewRequestDTO.class),
+            anyLong())).thenReturn(responseDTO);
+
+        // 리뷰 수정 요청 실행
+        this.mockMvc.perform(put("/api/v2/reviews/{reviewId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andDo(document("review-update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("title").type(JsonFieldType.STRING).description("리뷰 제목"),
+                    fieldWithPath("goodtags").type(JsonFieldType.ARRAY).description("좋은 태그 ID 목록"),
+                    fieldWithPath("badtags").type(JsonFieldType.ARRAY).description("나쁜 태그 ID 목록"),
+                    fieldWithPath("rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+                    fieldWithPath("content").type(JsonFieldType.STRING).description("리뷰 내용")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리뷰 ID"),
+                    fieldWithPath("data.bootcamp").type(JsonFieldType.STRING)
+                        .description("부트캠프 이름"),
+                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("리뷰 제목"),
+                    fieldWithPath("data.goodtags").type(JsonFieldType.ARRAY)
+                        .description("좋아요 태그 목록"),
+                    fieldWithPath("data.badtags").type(JsonFieldType.ARRAY)
+                        .description("나빠요 태그 목록"),
+                    fieldWithPath("data.rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("리뷰 내용")
                 )
             ));
     }

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -2,11 +2,13 @@ package com.fasttime.domain.review.docs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -19,12 +21,12 @@ import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.SecurityUtil;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-
 
 class ReviewControllerDocsTest extends RestDocsSupport {
 
@@ -140,6 +142,35 @@ class ReviewControllerDocsTest extends RestDocsSupport {
                         .description("나빠요 태그 목록"),
                     fieldWithPath("data.rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
                     fieldWithPath("data.content").type(JsonFieldType.STRING).description("리뷰 내용")
+                )
+            ));
+    }
+
+    @DisplayName("전체 리뷰 조회 API 문서화")
+    @Test
+    void getReviews() throws Exception {
+        List<ReviewResponseDTO> reviews = List.of(
+            new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프", "리뷰 제목 1", Set.of("친절해요"), Set.of("불친절해요"), 5, "리뷰 내용 1"),
+            new ReviewResponseDTO(2L, "다른 부트캠프", "리뷰 제목 2", Set.of("강의가 좋아요"), Set.of("피드백이 느려요"), 4, "리뷰 내용 2")
+        );
+
+        when(reviewService.getSortedReviews(anyString())).thenReturn(reviews);
+
+        mockMvc.perform(get("/api/v2/reviews/all"))
+            .andExpect(status().isOk())
+            .andDo(document("reviews-get-all",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                    fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("리뷰 ID"),
+                    fieldWithPath("data[].bootcamp").type(JsonFieldType.STRING).description("부트캠프 이름"),
+                    fieldWithPath("data[].title").type(JsonFieldType.STRING).description("리뷰 제목"),
+                    fieldWithPath("data[].goodtags").type(JsonFieldType.ARRAY).description("좋아요 태그 목록"),
+                    fieldWithPath("data[].badtags").type(JsonFieldType.ARRAY).description("나빠요 태그 목록"),
+                    fieldWithPath("data[].rating").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+                    fieldWithPath("data[].content").type(JsonFieldType.STRING).description("리뷰 내용")
                 )
             ));
     }

--- a/src/test/java/com/fasttime/domain/review/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/controller/ReviewControllerTest.java
@@ -1,0 +1,324 @@
+package com.fasttime.domain.review.unit.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.fasttime.domain.member.exception.MemberNotFoundException;
+import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
+import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
+import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
+import com.fasttime.domain.review.exception.ReviewAlreadyExistsException;
+import com.fasttime.domain.review.exception.ReviewNotFoundException;
+import com.fasttime.domain.review.exception.TagNotFoundException;
+import com.fasttime.domain.review.exception.UnauthorizedAccessException;
+import com.fasttime.util.ControllerUnitTestSupporter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.mockito.stubbing.OngoingStubbing;
+import org.springframework.http.MediaType;
+
+class ReviewControllerTest extends ControllerUnitTestSupporter {
+
+    @Nested
+    @DisplayName("리뷰 작성은")
+    class Describe_createReview {
+
+        @Test
+        @DisplayName("유효한 리뷰 요청이 주어지면 리뷰를 생성한다.")
+        void whenValidRequest_thenCreateReviewAndReturnStatus201() throws Exception {
+            // given
+            ReviewRequestDTO requestDTO = new ReviewRequestDTO("테스트 리뷰 제목", Set.of(1L, 2L),
+                Set.of(3L, 4L), 5, "테스트 리뷰 내용");
+            ReviewResponseDTO responseDTO = new ReviewResponseDTO(1L, "패스트캠퍼스X야놀자 부트캠프",
+                "테스트 리뷰 제목", Set.of("긍정 태그"), Set.of("부정 태그"), 5, "테스트 리뷰 내용");
+
+            when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class),
+                anyLong())).thenReturn(responseDTO);
+
+            // when, then
+            mockMvc.perform(post("/api/v2/reviews")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value(responseDTO.title()))
+                .andExpect(jsonPath("$.data.content").value(responseDTO.content()));
+        }
+
+        @Test
+        @DisplayName("권한이 없을 경우 실패한다.")
+        void whenUserIsUnauthorized_thenReturnStatus403() throws Exception {
+            // given
+            OngoingStubbing<ReviewResponseDTO> requestDTO =
+                when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class),
+                    anyLong()))
+                    .thenThrow(new UnauthorizedAccessException());
+
+            // when, then
+            mockMvc.perform(post("/api/v2/reviews")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자가 작성하면 실패한다.")
+        void whenUserDoesNotExist_thenReturnStatus404() throws Exception {
+            // given
+            OngoingStubbing<ReviewResponseDTO> requestDTO =
+                when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class),
+                    anyLong()))
+                    .thenThrow(new MemberNotFoundException());
+
+            // when, then
+            mockMvc.perform(post("/api/v2/reviews")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("중복 작성시 실패한다.")
+        void whenReviewAlreadyExists_thenReturnStatus409() throws Exception {
+            // given
+            ReviewRequestDTO requestDTO = new ReviewRequestDTO("테스트 리뷰 제목", Set.of(1L, 2L),
+                Set.of(3L, 4L), 5, "테스트 리뷰 내용");
+            when(
+                reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class), anyLong()))
+                .thenThrow(new ReviewAlreadyExistsException());
+
+            // when, then
+            mockMvc.perform(post("/api/v2/reviews")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 태그를 사용할 경우 실패한다.")
+        void whenTagNotFound_thenReturnStatus400() throws Exception {
+            // given
+            ReviewRequestDTO requestDTO = new ReviewRequestDTO("테스트 리뷰 제목", Set.of(1L, 2L),
+                Set.of(3L, 4L), 5, "테스트 리뷰 내용");
+            when(
+                reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class), anyLong()))
+                .thenThrow(new TagNotFoundException());
+
+            // when, then
+            mockMvc.perform(post("/api/v2/reviews")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 삭제는")
+    class Describe_deleteReview {
+
+        @Test
+        @DisplayName("성공한다.")
+        void whenValidUserDeletesReview_thenReturnStatus200AndSuccessMessage() throws Exception {
+            // given
+            Long reviewId = 1L;
+            doNothing().when(reviewService).deleteReview(eq(reviewId), anyLong());
+
+            // when, then
+            mockMvc.perform(delete("/api/v2/reviews/{reviewId}", reviewId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("리뷰 요청이 완료되었습니다."));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰를 삭제할 경우 실패한다.")
+        void whenDeleteNonExistingReview_thenReturnStatus404() throws Exception {
+            // given
+            Long reviewId = 1L;
+            doThrow(new ReviewNotFoundException()).when(reviewService)
+                .deleteReview(eq(reviewId), anyLong());
+
+            // when, then
+            mockMvc.perform(delete("/api/v2/reviews/{reviewId}", reviewId))
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("권한이 없는 사용자는 실패한다.")
+        void whenUnauthorizedUserTriesToDeleteReview_thenReturnStatus403() throws Exception {
+            // given
+            Long reviewId = 1L;
+            doThrow(new UnauthorizedAccessException()).when(reviewService)
+                .deleteReview(eq(reviewId), anyLong());
+
+            // when, then
+            mockMvc.perform(delete("/api/v2/reviews/{reviewId}", reviewId))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 수정은")
+    class Describe_updateReview {
+
+        @Test
+        @DisplayName("성공한다.")
+        void whenValidUserUpdatesReview_thenReturnStatus200AndUpdatedReview() throws Exception {
+            // given
+            Long reviewId = 1L;
+            ReviewRequestDTO requestDTO = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(1L), Set.of(2L),
+                4, "수정된 리뷰 내용");
+            ReviewResponseDTO responseDTO = new ReviewResponseDTO(reviewId, "패스트캠퍼스X야놀자 부트캠프",
+                "수정된 리뷰 제목", Set.of("긍정 태그"), Set.of("부정 태그"), 4, "수정된 리뷰 내용");
+
+            when(reviewService.updateAndReturnReviewResponse(eq(reviewId),
+                any(ReviewRequestDTO.class), anyLong())).thenReturn(responseDTO);
+
+            // when, then
+            mockMvc.perform(put("/api/v2/reviews/{reviewId}", reviewId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value(responseDTO.title()))
+                .andExpect(jsonPath("$.data.content").value(responseDTO.content()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰를 수정할 경우 실패한다.")
+        void whenUpdateNonExistingReview_thenReturnStatus404() throws Exception {
+            // given
+            Long reviewId = 1L;
+            ReviewRequestDTO requestDTO = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(1L), Set.of(2L),
+                4, "수정된 리뷰 내용");
+
+            doThrow(new ReviewNotFoundException()).when(reviewService)
+                .updateAndReturnReviewResponse(eq(reviewId), any(ReviewRequestDTO.class),
+                    anyLong());
+
+            // when, then
+            mockMvc.perform(put("/api/v2/reviews/{reviewId}", reviewId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("권한이 없는 사용자는 실패한다.")
+        void whenUnauthorizedUserTriesToUpdateReview_thenReturnStatus403() throws Exception {
+            // given
+            Long reviewId = 1L;
+            ReviewRequestDTO requestDTO = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(1L), Set.of(2L),
+                4, "수정된 리뷰 내용");
+
+            doThrow(new UnauthorizedAccessException()).when(reviewService)
+                .updateAndReturnReviewResponse(eq(reviewId), any(ReviewRequestDTO.class),
+                    anyLong());
+
+            // when, then
+            mockMvc.perform(put("/api/v2/reviews/{reviewId}", reviewId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 조회는")
+    class Describe_get_all_Review {
+
+        @Test
+        @DisplayName("전체조회를 성공한다.")
+        void whenGetAllReviews_thenReturnStatus200AndAllReviews() throws Exception {
+            // given
+            List<ReviewResponseDTO> reviews = Arrays.asList(
+                new ReviewResponseDTO(1L, "부트캠프1", "리뷰1", Set.of("긍정 태그1"), Set.of("부정 태그1"), 5,
+                    "리뷰 내용1"),
+                new ReviewResponseDTO(2L, "부트캠프2", "리뷰2", Set.of("긍정 태그2"), Set.of("부정 태그2"), 4,
+                    "리뷰 내용2")
+            );
+
+            when(reviewService.getSortedReviews(anyString())).thenReturn(reviews);
+
+            // when, then
+            mockMvc.perform(get("/api/v2/reviews/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].id").value(reviews.get(0).id()))
+                .andExpect(jsonPath("$.data[0].bootcamp").value(reviews.get(0).bootcamp()))
+                .andExpect(jsonPath("$.data[0].title").value(reviews.get(0).title()))
+                .andExpect(jsonPath("$.data[0].rating").value(reviews.get(0).rating()))
+                .andExpect(jsonPath("$.data[0].content").value(reviews.get(0).content()))
+                .andExpect(jsonPath("$.data[1].id").value(reviews.get(1).id()))
+                .andExpect(jsonPath("$.data[1].bootcamp").value(reviews.get(1).bootcamp()))
+                .andExpect(jsonPath("$.data[1].title").value(reviews.get(1).title()))
+                .andExpect(jsonPath("$.data[1].rating").value(reviews.get(1).rating()))
+                .andExpect(jsonPath("$.data[1].content").value(reviews.get(1).content()));
+        }
+
+        @Test
+        @DisplayName("부트캠프별 리뷰 조회를 성공한다.")
+        void whenGetReviewsByBootcamp_thenReturnStatus200AndReviews() throws Exception {
+            // given
+            String bootcampName = "패스트캠퍼스X야놀자 부트캠프";
+            List<ReviewResponseDTO> reviews = Arrays.asList(
+                new ReviewResponseDTO(1L, bootcampName, "리뷰1", Set.of("긍정적 태그1"), Set.of("부정적 태그1"),
+                    5, "리뷰 내용1"),
+                new ReviewResponseDTO(2L, bootcampName, "리뷰2", Set.of("긍정적 태그2"), Set.of("부정적 태그2"),
+                    4, "리뷰 내용2")
+            );
+
+            when(reviewService.getReviewsByBootcamp(eq(bootcampName), anyString())).thenReturn(
+                reviews);
+
+            // when, then
+            mockMvc.perform(get("/api/v2/reviews/by-bootcamp")
+                    .param("bootcamp", bootcampName))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].id").value(reviews.get(0).id()))
+                .andExpect(jsonPath("$.data[0].bootcamp").value(reviews.get(0).bootcamp()))
+                .andExpect(jsonPath("$.data[0].title").value(reviews.get(0).title()))
+                .andExpect(jsonPath("$.data[0].rating").value(reviews.get(0).rating()))
+                .andExpect(jsonPath("$.data[0].content").value(reviews.get(0).content()))
+                .andExpect(jsonPath("$.data[1].id").value(reviews.get(1).id()))
+                .andExpect(jsonPath("$.data[1].bootcamp").value(reviews.get(1).bootcamp()))
+                .andExpect(jsonPath("$.data[1].title").value(reviews.get(1).title()))
+                .andExpect(jsonPath("$.data[1].rating").value(reviews.get(1).rating()))
+                .andExpect(jsonPath("$.data[1].content").value(reviews.get(1).content()));
+        }
+
+        @Test
+        @DisplayName("부트캠프별 리뷰 요약 조회에 성공한다.")
+        void whenGetBootcampReviewSummaries_thenReturnStatus200AndSummaries() throws Exception {
+            // given
+            List<BootcampReviewSummaryDTO> summaries = Arrays.asList(
+                new BootcampReviewSummaryDTO("패스트캠퍼스X야놀자 부트캠프", 4.5, 10, 20,
+                    Map.of(1L, 5L, 2L, 5L)),
+                new BootcampReviewSummaryDTO("다른 부트캠프", 3.5, 8, 15, Map.of(3L, 4L, 4L, 4L))
+            );
+
+            when(reviewService.getBootcampReviewSummaries()).thenReturn(summaries);
+
+            // when, then
+            mockMvc.perform(get("/api/v2/reviews/by-bootcamp/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].bootcamp").value(summaries.get(0).bootcamp()))
+                .andExpect(
+                    jsonPath("$.data[0].averageRating").value(summaries.get(0).averageRating()))
+                .andExpect(
+                    jsonPath("$.data[0].totalReviews").value(summaries.get(0).totalReviews()))
+                .andExpect(jsonPath("$.data[0].totalTags").value(summaries.get(0).totalTags()))
+                .andExpect(jsonPath("$.data[1].bootcamp").value(summaries.get(1).bootcamp()))
+                .andExpect(
+                    jsonPath("$.data[1].averageRating").value(summaries.get(1).averageRating()))
+                .andExpect(
+                    jsonPath("$.data[1].totalReviews").value(summaries.get(1).totalReviews()))
+                .andExpect(jsonPath("$.data[1].totalTags").value(summaries.get(1).totalTags()));
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/review/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/controller/ReviewControllerTest.java
@@ -26,12 +26,12 @@ import org.springframework.http.MediaType;
 class ReviewControllerTest extends ControllerUnitTestSupporter {
 
     @Nested
-    @DisplayName("리뷰 작성은")
+    @DisplayName("createReview()는")
     class Describe_createReview {
 
         @Test
         @DisplayName("유효한 리뷰 요청이 주어지면 리뷰를 생성한다.")
-        void whenValidRequest_thenCreateReviewAndReturnStatus201() throws Exception {
+        void _willSuccess() throws Exception {
             // given
             ReviewRequestDTO requestDTO = new ReviewRequestDTO("테스트 리뷰 제목", Set.of(1L, 2L),
                 Set.of(3L, 4L), 5, "테스트 리뷰 내용");
@@ -52,7 +52,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("권한이 없을 경우 실패한다.")
-        void whenUserIsUnauthorized_thenReturnStatus403() throws Exception {
+        void Unauthorized_willFail() throws Exception {
             // given
             OngoingStubbing<ReviewResponseDTO> requestDTO =
                 when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class),
@@ -68,7 +68,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("존재하지 않는 사용자가 작성하면 실패한다.")
-        void whenUserDoesNotExist_thenReturnStatus404() throws Exception {
+        void NotFound_willFail() throws Exception {
             // given
             OngoingStubbing<ReviewResponseDTO> requestDTO =
                 when(reviewService.createAndReturnReviewResponse(any(ReviewRequestDTO.class),
@@ -84,7 +84,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("중복 작성시 실패한다.")
-        void whenReviewAlreadyExists_thenReturnStatus409() throws Exception {
+        void ConflictBadRequest_willFail() throws Exception {
             // given
             ReviewRequestDTO requestDTO = new ReviewRequestDTO("테스트 리뷰 제목", Set.of(1L, 2L),
                 Set.of(3L, 4L), 5, "테스트 리뷰 내용");
@@ -101,7 +101,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("존재하지 않는 태그를 사용할 경우 실패한다.")
-        void whenTagNotFound_thenReturnStatus400() throws Exception {
+        void TagBadRequest_willFail() throws Exception {
             // given
             ReviewRequestDTO requestDTO = new ReviewRequestDTO("테스트 리뷰 제목", Set.of(1L, 2L),
                 Set.of(3L, 4L), 5, "테스트 리뷰 내용");
@@ -118,12 +118,12 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
     }
 
     @Nested
-    @DisplayName("리뷰 삭제는")
+    @DisplayName("deleteReview()는")
     class Describe_deleteReview {
 
         @Test
         @DisplayName("성공한다.")
-        void whenValidUserDeletesReview_thenReturnStatus200AndSuccessMessage() throws Exception {
+        void _willSuccess() throws Exception {
             // given
             Long reviewId = 1L;
             doNothing().when(reviewService).deleteReview(eq(reviewId), anyLong());
@@ -136,7 +136,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("존재하지 않는 리뷰를 삭제할 경우 실패한다.")
-        void whenDeleteNonExistingReview_thenReturnStatus404() throws Exception {
+        void NotFound_willFail() throws Exception {
             // given
             Long reviewId = 1L;
             doThrow(new ReviewNotFoundException()).when(reviewService)
@@ -149,7 +149,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("권한이 없는 사용자는 실패한다.")
-        void whenUnauthorizedUserTriesToDeleteReview_thenReturnStatus403() throws Exception {
+        void Unauthorized_willFail() throws Exception {
             // given
             Long reviewId = 1L;
             doThrow(new UnauthorizedAccessException()).when(reviewService)
@@ -162,12 +162,12 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
     }
 
     @Nested
-    @DisplayName("리뷰 수정은")
+    @DisplayName("updateReview()는")
     class Describe_updateReview {
 
         @Test
         @DisplayName("성공한다.")
-        void whenValidUserUpdatesReview_thenReturnStatus200AndUpdatedReview() throws Exception {
+        void _willSuccess() throws Exception {
             // given
             Long reviewId = 1L;
             ReviewRequestDTO requestDTO = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(1L), Set.of(2L),
@@ -189,7 +189,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("존재하지 않는 리뷰를 수정할 경우 실패한다.")
-        void whenUpdateNonExistingReview_thenReturnStatus404() throws Exception {
+        void NotFound_willFail() throws Exception {
             // given
             Long reviewId = 1L;
             ReviewRequestDTO requestDTO = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(1L), Set.of(2L),
@@ -208,7 +208,7 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
 
         @Test
         @DisplayName("권한이 없는 사용자는 실패한다.")
-        void whenUnauthorizedUserTriesToUpdateReview_thenReturnStatus403() throws Exception {
+        void Unauthorized_willFail() throws Exception {
             // given
             Long reviewId = 1L;
             ReviewRequestDTO requestDTO = new ReviewRequestDTO("수정된 리뷰 제목", Set.of(1L), Set.of(2L),
@@ -231,8 +231,8 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
     class Describe_get_all_Review {
 
         @Test
-        @DisplayName("전체조회를 성공한다.")
-        void whenGetAllReviews_thenReturnStatus200AndAllReviews() throws Exception {
+        @DisplayName("getReviews()를 성공한다.")
+        void all_willSuccess() throws Exception {
             // given
             List<ReviewResponseDTO> reviews = Arrays.asList(
                 new ReviewResponseDTO(1L, "부트캠프1", "리뷰1", Set.of("긍정 태그1"), Set.of("부정 태그1"), 5,
@@ -260,8 +260,8 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
         }
 
         @Test
-        @DisplayName("부트캠프별 리뷰 조회를 성공한다.")
-        void whenGetReviewsByBootcamp_thenReturnStatus200AndReviews() throws Exception {
+        @DisplayName("getReviewsByBootcamp()를 성공한다.")
+        void bootcamp_willSuccess() throws Exception {
             // given
             String bootcampName = "패스트캠퍼스X야놀자 부트캠프";
             List<ReviewResponseDTO> reviews = Arrays.asList(
@@ -292,8 +292,8 @@ class ReviewControllerTest extends ControllerUnitTestSupporter {
         }
 
         @Test
-        @DisplayName("부트캠프별 리뷰 요약 조회에 성공한다.")
-        void whenGetBootcampReviewSummaries_thenReturnStatus200AndSummaries() throws Exception {
+        @DisplayName("getBootcampReviewSummaries()를 성공한다.")
+        void bootcampSummary_willSuccess() throws Exception {
             // given
             List<BootcampReviewSummaryDTO> summaries = Arrays.asList(
                 new BootcampReviewSummaryDTO("패스트캠퍼스X야놀자 부트캠프", 4.5, 10, 20,

--- a/src/test/java/com/fasttime/domain/review/unit/entity/ReviewTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/entity/ReviewTest.java
@@ -1,0 +1,102 @@
+package com.fasttime.domain.review.unit.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasttime.domain.review.entity.Review;
+import com.fasttime.domain.review.entity.ReviewTag;
+import com.fasttime.domain.member.entity.Member;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ReviewTest {
+
+    @DisplayName("리뷰를 생성할 수 있다.")
+    @Test
+    void create_review_willSuccess() {
+        // given
+        String title = "제목";
+        String content = "내용";
+        String bootcamp = "부트캠프";
+        int rating = 5;
+
+        // when
+        Review review = Review.builder()
+            .title(title)
+            .content(content)
+            .bootcamp(bootcamp)
+            .rating(rating)
+            .member(new Member())
+            .build();
+
+        // then
+        assertThat(review).extracting("title", "content", "bootcamp", "rating")
+            .containsExactly(title, content, bootcamp, rating);
+    }
+
+    @DisplayName("리뷰 내용을 수정할 수 있다.")
+    @Test
+    void update_review_willSuccess() {
+        // given
+        Review review = Review.builder()
+            .title("원래 제목")
+            .content("원래 내용")
+            .bootcamp("부트캠프")
+            .rating(5)
+            .build();
+        String updatedTitle = "수정된 제목";
+        String updatedContent = "수정된 내용";
+        int updatedRating = 4;
+
+        // when
+        review.updateReviewDetails(updatedTitle, updatedRating, updatedContent);
+
+        // then
+        assertThat(review).extracting("title", "content", "rating")
+            .containsExactly(updatedTitle, updatedContent, updatedRating);
+    }
+
+    @DisplayName("리뷰에 태그를 설정할 수 있다.")
+    @Test
+    void set_reviewTags_willSuccess() {
+        // given
+        Review review = Review.builder().build();
+        Set<ReviewTag> tags = new HashSet<>();
+        tags.add(new ReviewTag());
+
+        // when
+        review.setReviewTags(tags);
+
+        // then
+        assertTrue(review.getReviewTags().containsAll(tags));
+    }
+
+    @DisplayName("리뷰를 삭제할 수 있다.")
+    @Test
+    void delete_review_willSuccess() {
+        // given
+        Review review = Review.builder().build();
+
+        // when
+        review.softDelete();
+
+        // then
+        assertTrue(review.isDeleted());
+    }
+
+    @DisplayName("리뷰를 복구할 수 있다.")
+    @Test
+    void restore_willSuccess() {
+        // given
+        Review review = Review.builder().build();
+        review.softDelete();
+
+        // when
+        review.restore();
+
+        // then
+        assertTrue(!review.isDeleted());
+    }
+}

--- a/src/test/java/com/fasttime/domain/review/unit/entity/TagTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/entity/TagTest.java
@@ -1,0 +1,38 @@
+package com.fasttime.domain.review.unit.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasttime.domain.review.entity.ReviewTag;
+import com.fasttime.domain.review.entity.Tag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class TagTest {
+
+    @DisplayName("Tag 엔터티를 생성할 수 있다.")
+    @Test
+    void create_Tag_willSuccess() {
+        // given
+        String content = "태그 내용";
+
+        // when
+        Tag tag = Tag.create(content);
+
+        // then
+        assertThat(tag.getContent()).isEqualTo(content);
+    }
+
+    @DisplayName("Tag 엔터티에 ReviewTag를 연결할 수 있다.")
+    @Test
+    void associate_ReviewTag_willSuccess() {
+        // given
+        Tag tag = Tag.create("태그 내용");
+        ReviewTag reviewTag = new ReviewTag();
+
+        // when
+        tag.getReviewTags().add(reviewTag);
+
+        // then
+        assertThat(tag.getReviewTags()).contains(reviewTag);
+    }
+}

--- a/src/test/java/com/fasttime/domain/review/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/service/ReviewServiceTest.java
@@ -1,0 +1,357 @@
+package com.fasttime.domain.review.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.HashSet;
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.entity.Role;
+import com.fasttime.domain.member.exception.MemberNotFoundException;
+import com.fasttime.domain.member.repository.MemberRepository;
+import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
+import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
+import com.fasttime.domain.review.entity.Review;
+import com.fasttime.domain.review.exception.ReviewNotFoundException;
+import com.fasttime.domain.review.repository.ReviewRepository;
+import com.fasttime.domain.review.repository.ReviewTagRepository;
+import com.fasttime.domain.review.service.ReviewService;
+import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
+import com.fasttime.domain.review.exception.UnauthorizedAccessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ReviewTagRepository reviewTagRepository;
+
+    private Member member;
+
+    private ReviewRequestDTO reviewRequestDTO;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+            .id(1L)
+            .email("test@example.com")
+            .password("password")
+            .nickname("nickname")
+            .campCrtfc(true)
+            .bootcamp("패스트캠퍼스X야놀자 부트캠프")
+            .role(Role.ROLE_USER)
+            .build();
+        reviewRequestDTO = new ReviewRequestDTO(
+            "테스트 리뷰",
+            new HashSet<>(),
+            new HashSet<>(),
+            5,
+            "좋아용"
+        );
+    }
+
+    @Nested
+    @DisplayName("createAndReturnReviewResponse()는 ")
+    class Context_getComments {
+
+        @Test
+        @DisplayName("리뷰 작성에 성공한다.")
+        void new_create_willSuccess() {
+            // given
+            given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(member));
+            given(reviewRepository.save(any(Review.class))).willReturn(
+                reviewRequestDTO.createReview(member));
+            // when
+            ReviewResponseDTO result = reviewService.createAndReturnReviewResponse(reviewRequestDTO,
+                1L);
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.title()).isEqualTo("테스트 리뷰");
+            assertThat(result.rating()).isEqualTo(5);
+            assertThat(result.content()).isEqualTo("좋아용");
+
+            // Verify interactions
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(reviewRepository, times(1)).save(any(Review.class));
+        }
+
+        @Test
+        @DisplayName("권한이 없을 경우 실패한다.")
+        void Unauthorized_willFail() {
+            // given
+            Member unauthorizedMember = Member.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .nickname(member.getNickname())
+                .campCrtfc(false)
+                .bootcamp(member.getBootcamp())
+                .role(member.getRole())
+                .build();
+
+            given(memberRepository.findById(anyLong())).willReturn(Optional.of(unauthorizedMember));
+
+            // when, then
+            assertThrows(UnauthorizedAccessException.class, () -> {
+                reviewService.createReview(reviewRequestDTO, unauthorizedMember.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("존재하지 않은 사용자가 시도하면 실패한다.")
+        void NotFound_willFail() {
+            // given
+            given(memberRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+            // when, then
+            assertThrows(MemberNotFoundException.class, () -> {
+                reviewService.createAndReturnReviewResponse(reviewRequestDTO, 1L);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteReview()는")
+    class Context_deleteReview {
+
+        @Test
+        @DisplayName("성공한다.")
+        void deleteReview_willSuccess() {
+            // given
+            Review mockReview = Mockito.mock(Review.class);
+            given(reviewRepository.findById(anyLong())).willReturn(Optional.of(mockReview));
+            given(mockReview.getMember()).willReturn(member);
+
+            // when
+            reviewService.deleteReview(1L, member.getId());
+
+            // then
+            verify(reviewRepository, times(1)).save(mockReview);
+        }
+
+        @Test
+        @DisplayName("리뷰를 찾을 수 없으면 실패한다.")
+        void NotFound_willFail() {
+            // given
+            given(reviewRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            // when, then
+            assertThrows(ReviewNotFoundException.class, () -> {
+                reviewService.deleteReview(1L, member.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("권한이 없는 사용자는 실패한다.")
+        void Unauthorized_willFail() {
+            // given
+            Review mockReview = Mockito.mock(Review.class);
+            Member otherMember = Member.builder().id(2L).build();
+            given(reviewRepository.findById(anyLong())).willReturn(Optional.of(mockReview));
+            given(mockReview.getMember()).willReturn(otherMember);
+
+            // when, then
+            assertThrows(UnauthorizedAccessException.class, () -> {
+                reviewService.deleteReview(1L, member.getId());
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("updateReview()는")
+    class Context_updateReview {
+
+        @Test
+        @DisplayName("성공한다.")
+        void _willSuccess() {
+            // given
+            Review existingReview = Mockito.mock(Review.class);
+            given(reviewRepository.findById(anyLong())).willReturn(Optional.of(existingReview));
+            given(existingReview.getMember()).willReturn(member);
+
+            // when
+            reviewService.updateReview(1L, reviewRequestDTO, member.getId());
+
+            // then
+            verify(reviewRepository, times(1)).save(existingReview);
+        }
+
+        @Test
+        @DisplayName("리뷰를 찾을 수 없으면 실패한다.")
+        void NotFound_willFail() {
+            // given
+            given(reviewRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            // when, then
+            assertThrows(ReviewNotFoundException.class, () -> {
+                reviewService.updateReview(1L, reviewRequestDTO, member.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("권한이 없는 사용자는 실패한다.")
+        void Unauthorized_willFail() {
+            // given
+            Review existingReview = Mockito.mock(Review.class);
+            Member otherMember = Member.builder().id(2L).build();
+            given(reviewRepository.findById(anyLong())).willReturn(Optional.of(existingReview));
+            given(existingReview.getMember()).willReturn(otherMember);
+
+            // when, then
+            assertThrows(UnauthorizedAccessException.class, () -> {
+                reviewService.updateReview(1L, reviewRequestDTO, member.getId());
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("getSortedReviews()는")
+    class Context_getSortedReviews {
+
+        @Test
+        @DisplayName("모든 리뷰를 정렬 기준에 따라 조회한다.")
+        void _willSuccess() {
+            // given
+            List<Review> mockReviews = createMockReviews();
+            given(reviewRepository.findAll(any(Sort.class))).willReturn(mockReviews);
+
+            // when
+            List<ReviewResponseDTO> result = reviewService.getSortedReviews("createdAt");
+
+            // then
+            assertThat(result).hasSize(mockReviews.size());
+            assertThat(result.get(0).id()).isEqualTo(mockReviews.get(0).getId());
+            assertThat(result.get(1).id()).isEqualTo(mockReviews.get(1).getId());
+
+            // Verify interactions
+            verify(reviewRepository, times(1)).findAll(any(Sort.class));
+        }
+
+        private List<Review> createMockReviews() {
+            Review review1 = new Review(1L, "리뷰 1", "부트캠프1", 5, "내용 1", new HashSet<>(), member);
+            Review review2 = new Review(2L, "리뷰 2", "부트캠프2", 4, "내용 2", new HashSet<>(), member);
+            return List.of(review1, review2);
+        }
+    }
+
+    @Nested
+    @DisplayName("getReviewsByBootcamp()는")
+    class Context_getReviewsByBootcamp {
+
+        @Test
+        @DisplayName("부트캠프별 리뷰를 정렬 기준에 따라 조회한다.")
+        void _willSuccess() {
+            // given
+            String bootcampName = "부트캠프1";
+            List<Review> mockReviews = createMockReviewsForBootcamp(bootcampName);
+            given(reviewRepository.findByBootcamp(anyString(), any(Sort.class))).willReturn(
+                mockReviews);
+
+            // when
+            List<ReviewResponseDTO> result = reviewService.getReviewsByBootcamp(bootcampName,
+                "createdAt");
+
+            // then
+            assertThat(result).hasSize(mockReviews.size());
+            assertThat(result.get(0).bootcamp()).isEqualTo(bootcampName);
+            assertThat(result.get(1).bootcamp()).isEqualTo(bootcampName);
+
+            // Verify interactions
+            verify(reviewRepository, times(1)).findByBootcamp(anyString(), any(Sort.class));
+        }
+
+        private List<Review> createMockReviewsForBootcamp(String bootcampName) {
+            Review review1 = new Review(1L, "리뷰 1", bootcampName, 5, "내용 1", new HashSet<>(),
+                member);
+            Review review2 = new Review(2L, "리뷰 2", bootcampName, 4, "내용 2", new HashSet<>(),
+                member);
+            return List.of(review1, review2);
+        }
+    }
+
+    @Nested
+    @DisplayName("getBootcampReviewSummaries()는")
+    class Context_getBootcampReviewSummaries {
+
+        @Test
+        @DisplayName("부트캠프별 리뷰 요약 정보를 조회한다.")
+        void _willSuccess() {
+            // given
+            List<String> bootcamps = List.of("부트캠프1", "부트캠프2");
+            List<BootcampReviewSummaryDTO> summaries = createMockSummaries(bootcamps);
+            given(reviewRepository.findAllBootcamps()).willReturn(bootcamps);
+            for (String bootcamp : bootcamps) {
+                given(reviewRepository.findAverageRatingByBootcamp(bootcamp)).willReturn(4.5);
+                given(reviewRepository.countByBootcamp(bootcamp)).willReturn(10);
+                given(reviewTagRepository.countByBootcamp(bootcamp)).willReturn(20);
+            }
+
+            // when
+            List<BootcampReviewSummaryDTO> result = reviewService.getBootcampReviewSummaries();
+
+            // then
+            assertThat(result).hasSize(summaries.size());
+            assertThat(result.get(0).bootcamp()).isEqualTo(summaries.get(0).bootcamp());
+            assertThat(result.get(1).bootcamp()).isEqualTo(summaries.get(1).bootcamp());
+
+            // Verify interactions
+            verify(reviewRepository, times(1)).findAllBootcamps();
+            for (String bootcamp : bootcamps) {
+                verify(reviewRepository, times(1)).findAverageRatingByBootcamp(bootcamp);
+                verify(reviewRepository, times(1)).countByBootcamp(bootcamp);
+                verify(reviewTagRepository, times(1)).countByBootcamp(bootcamp);
+            }
+        }
+
+        @Test
+        @DisplayName("부트캠프별 리뷰 요약 정보가 없을 경우 처리한다.")
+        void NoData_willHandle() {
+            // given
+            given(reviewRepository.findAllBootcamps()).willReturn(new ArrayList<>());
+
+            // when
+            List<BootcampReviewSummaryDTO> result = reviewService.getBootcampReviewSummaries();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        private List<BootcampReviewSummaryDTO> createMockSummaries(List<String> bootcamps) {
+            List<BootcampReviewSummaryDTO> summaries = new ArrayList<>();
+            for (String bootcamp : bootcamps) {
+                summaries.add(
+                    new BootcampReviewSummaryDTO(bootcamp, 4.5, 10, 20, Map.of(1L, 5L, 2L, 5L)));
+            }
+            return summaries;
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/review/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/service/ReviewServiceTest.java
@@ -242,9 +242,24 @@ public class ReviewServiceTest {
 
         @Test
         @DisplayName("모든 리뷰를 정렬 기준에 따라 조회한다.")
-        void _willSuccess() {
+        void withoutBootcampFilter_willSuccess() {
             // given
-            String bootcampName = "패스트캠퍼스X야놀자 부트캠프";
+            List<Review> mockReviews = createMockReviews();
+            given(reviewRepository.findAll(any(Sort.class))).willReturn(mockReviews);
+
+            // when
+            List<ReviewResponseDTO> result = reviewService.getSortedReviews("createdAt", null);
+
+            // then
+            assertThat(result).hasSize(mockReviews.size());
+            verify(reviewRepository, times(1)).findAll(any(Sort.class));
+        }
+
+        @Test
+        @DisplayName("부트캠프별 리뷰를 정렬 기준에 따라 조회한다.")
+        void withBootcampFilter_willSuccess() {
+            // given
+            String bootcampName = "부트캠프1";
             List<Review> mockReviews = createMockReviewsForBootcamp(bootcampName);
             given(reviewRepository.findByBootcamp(anyString(), any(Sort.class))).willReturn(
                 mockReviews);
@@ -255,45 +270,16 @@ public class ReviewServiceTest {
 
             // then
             assertThat(result).hasSize(mockReviews.size());
-            assertThat(result.get(0).id()).isEqualTo(mockReviews.get(0).getId());
-            assertThat(result.get(1).id()).isEqualTo(mockReviews.get(1).getId());
-
-            verify(reviewRepository, times(1)).findByBootcamp(anyString(), any(Sort.class));
-        }
-
-        private List<Review> createMockReviewsForBootcamp(String bootcampName) {
-            Review review1 = new Review(1L, "리뷰 1", bootcampName, 5, "내용 1", new HashSet<>(),
-                member);
-            Review review2 = new Review(2L, "리뷰 2", bootcampName, 4, "내용 2", new HashSet<>(),
-                member);
-            return List.of(review1, review2);
-        }
-    }
-
-    @Nested
-    @DisplayName("getReviewsByBootcamp()는")
-    class Context_getReviewsByBootcamp {
-
-        @Test
-        @DisplayName("부트캠프별 리뷰를 정렬 기준에 따라 조회한다.")
-        void _willSuccess() {
-            // given
-            String bootcampName = "부트캠프1";
-            List<Review> mockReviews = createMockReviewsForBootcamp(bootcampName);
-            given(reviewRepository.findByBootcamp(anyString(), any(Sort.class))).willReturn(
-                mockReviews);
-
-            // when
-            List<ReviewResponseDTO> result = reviewService.getReviewsByBootcamp(bootcampName,
-                "createdAt");
-
-            // then
-            assertThat(result).hasSize(mockReviews.size());
             assertThat(result.get(0).bootcamp()).isEqualTo(bootcampName);
             assertThat(result.get(1).bootcamp()).isEqualTo(bootcampName);
 
-            // Verify interactions
             verify(reviewRepository, times(1)).findByBootcamp(anyString(), any(Sort.class));
+        }
+
+        private List<Review> createMockReviews() {
+            Review review1 = new Review(1L, "리뷰 1", "부트캠프1", 5, "내용 1", new HashSet<>(), member);
+            Review review2 = new Review(2L, "리뷰 2", "부트캠프2", 4, "내용 2", new HashSet<>(), member);
+            return List.of(review1, review2);
         }
 
         private List<Review> createMockReviewsForBootcamp(String bootcampName) {
@@ -356,7 +342,8 @@ public class ReviewServiceTest {
         void _willSuccess() {
             // given
             String bootcampName = "부트캠프1";
-            given(reviewTagRepository.countTagsByBootcampGroupedByTagId(bootcampName)).willReturn(
+            given(
+                reviewTagRepository.countTagsByBootcampGroupedByTagId(bootcampName)).willReturn(
                 List.of(new Object[]{1L, 5L}, new Object[]{2L, 3L})
             );
 

--- a/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
+++ b/src/test/java/com/fasttime/util/ControllerUnitTestSupporter.java
@@ -17,6 +17,8 @@ import com.fasttime.domain.memberArticleLike.controller.MemberArticleLikeRestCon
 import com.fasttime.domain.memberArticleLike.service.MemberArticleLikeService;
 import com.fasttime.domain.report.contoller.ReportRestController;
 import com.fasttime.domain.report.service.ReportService;
+import com.fasttime.domain.review.controller.ReviewController;
+import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.config.SpringSecurityConfig;
 import com.fasttime.global.util.SecurityUtil;
 import org.apache.catalina.security.SecurityConfig;
@@ -30,7 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(value = {ArticleController.class, MemberController.class, ReportRestController.class,
     EmailController.class, AdminController.class, MemberArticleLikeRestController.class,
-    CommentRestController.class},
+    CommentRestController.class, ReviewController.class},
     excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, SpringSecurityConfig.class})},
     excludeAutoConfiguration = SecurityAutoConfiguration.class)
@@ -71,4 +73,7 @@ public abstract class ControllerUnitTestSupporter {
 
     @MockBean
     protected CommentService commentService;
+
+    @MockBean
+    protected ReviewService reviewService;
 }


### PR DESCRIPTION
## ⭐[feature] 리뷰 조회 구현

### [전체 리뷰 조회]
- 등록되어 있는 전체 리뷰를 조회
- 최신순(default), 별점순 정렬 가능
- 로그인 없이도 조회 가능
- 부트캠프 파라미터 없을시 전체 조회
   -> ex ) GET /api/v2/reviews/all

### [부트캠프별 리뷰 조회]
- 부트캠프별 리뷰를 조회
- 최신순(default), 별점순 정렬 가능
- 로그인 없이도 조회 가능
   -> ex )  GET /api/v2/reviews?bootcamp=부트캠프 이름
-------------------------
### [부트캠프 Summary]
- 부트캠프별 리뷰 정보를 요약하는 api 구현
- 부트캠프 이름, 평균 별점, 리뷰의 개수를 출력합니다.
- 로그인 없이도 조회 가능
- 엔드포인트 : GET /api/v2/reviews/summary
------------------------
### [부트캠프별 태그 그래프]
- 부트캠프별 태그 그래프 구현을 위한 api 구현
- 부트캠프별 총 사용 태그갯수, 개별 태그 개수를 출력합니다.
- 로그인 없이도 조회 가능
- 엔드포인트 : GET /api/v2/reviews/tag-graph?bootcamp=부트캠프 이름
-------------------
## ⭐[fix] 리뷰 등록, 수정 시 태그 문제 해결

문제 사항 :
 - 리뷰를 등록, 수정시 review_tag 테이블에 데이터 저장이 안됨.
 - goodtag, badtag 구분을 안하고 저장함 -> 조회시 태그 구분 불가 


변경 사항 :
 - Review 엔터티에 tag cascade 추가
 - goodtag, badtag 구분을 위해 ReviewTag에 boolean타입의 isGoodTag 추가
 - 리뷰 수정, 재등록시 기존 리뷰 태그 삭제 후 재등록하는 것으로 로직 수정
