### PR TITLE
[Feature] 리뷰 도메인 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
     // RestDocs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/src/main/java/com/fasttime/domain/review/entity/Review.java
+++ b/src/main/java/com/fasttime/domain/review/entity/Review.java
@@ -62,9 +62,4 @@ public class Review extends BaseTimeEntity {
     public void softDelete() {
         delete(LocalDateTime.now());
     }
-
-    @Override
-    public void restore() {
-        super.restore();
-    }
 }

--- a/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    Review findByMemberId(Long memberId);
+    List<Review> findByMemberId(Long memberId);
 
     @Query("SELECT DISTINCT r.bootCamp.name FROM Review r")
     List<String> findAllBootcamps();

--- a/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/fasttime/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,11 @@
 package com.fasttime.domain.review.repository;
 
 import com.fasttime.domain.review.entity.Review;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +24,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r WHERE r.bootCamp.name = :bootcampName")
     List<Review> findByBootcampName(@Param("bootcampName") String bootcampName, Sort sort);
+
+    @Modifying
+    @Query("DELETE FROM Review r WHERE r.deletedAt IS NOT NULL AND r.deletedAt <= :cutoffDate")
+    void deleteReviewsOlderThan7Days(@Param("cutoffDate") LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/fasttime/domain/review/service/BatchScheduler.java
+++ b/src/main/java/com/fasttime/domain/review/service/BatchScheduler.java
@@ -1,0 +1,25 @@
+package com.fasttime.domain.review.service;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@EnableScheduling
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job deleteOldReviewsJob;
+
+    public BatchScheduler(JobLauncher jobLauncher, Job deleteOldReviewsJob) {
+        this.jobLauncher = jobLauncher;
+        this.deleteOldReviewsJob = deleteOldReviewsJob;
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void runDeleteOldReviewsJob() throws JobExecutionException {
+        jobLauncher.run(deleteOldReviewsJob, new JobParameters());
+    }
+}

--- a/src/main/java/com/fasttime/domain/review/service/DeleteOldReviewsTasklet.java
+++ b/src/main/java/com/fasttime/domain/review/service/DeleteOldReviewsTasklet.java
@@ -1,0 +1,26 @@
+package com.fasttime.domain.review.service;
+
+import com.fasttime.domain.review.repository.ReviewRepository;
+import java.time.LocalDateTime;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+
+public class DeleteOldReviewsTasklet implements Tasklet {
+
+    private final ReviewRepository reviewRepository;
+
+    public DeleteOldReviewsTasklet(ReviewRepository reviewRepository) {
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(7);
+        reviewRepository.deleteReviewsOlderThan7Days(cutoffDate);
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -50,20 +50,14 @@ public class ReviewService {
             throw new UnauthorizedAccessException();
         }
 
-        Review existingReview = reviewRepository.findByMemberId(memberId);
-        if (existingReview != null) {
-            if (existingReview.isDeleted()) {
-                reviewTagRepository.deleteByReview(existingReview);
-                updateReview(existingReview, requestDTO);
-                existingReview.restore();
-                return reviewRepository.save(existingReview);
-            } else {
-                throw new ReviewAlreadyExistsException();
-            }
+        List<Review> existingReviews = reviewRepository.findByMemberId(memberId);
+        if (existingReviews.stream().anyMatch(review -> !review.isDeleted())) {
+            throw new ReviewAlreadyExistsException();
         }
 
         Review newReview = requestDTO.createReview(member);
         updateReviewTags(newReview, requestDTO);
+
         return reviewRepository.save(newReview);
     }
 

--- a/src/main/java/com/fasttime/global/config/BatchConfig.java
+++ b/src/main/java/com/fasttime/global/config/BatchConfig.java
@@ -1,0 +1,38 @@
+package com.fasttime.global.config;
+
+import com.fasttime.domain.review.repository.ReviewRepository;
+import com.fasttime.domain.review.service.DeleteOldReviewsTasklet;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.batch.core.repository.JobRepository;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+
+    @Bean
+    public Job deleteOldReviewsJob(JobRepository jobRepository, Step deleteOldReviewsStep) {
+        return new JobBuilder("deleteOldReviewsJob", jobRepository)
+            .start(deleteOldReviewsStep)
+            .build();
+    }
+
+    @Bean
+    public Step deleteOldReviewsStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, DeleteOldReviewsTasklet tasklet) {
+        return new StepBuilder("deleteOldReviewsStep", jobRepository)
+            .tasklet(tasklet, transactionManager)
+            .build();
+    }
+
+    @Bean
+    public DeleteOldReviewsTasklet deleteOldReviewsTasklet(ReviewRepository reviewRepository) {
+        return new DeleteOldReviewsTasklet(reviewRepository);
+    }
+}

--- a/src/test/java/com/fasttime/domain/review/unit/entity/ReviewTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/entity/ReviewTest.java
@@ -86,18 +86,4 @@ public class ReviewTest {
         // then
         assertTrue(review.isDeleted());
     }
-
-    @DisplayName("리뷰를 복구할 수 있다.")
-    @Test
-    void restore_willSuccess() {
-        // given
-        Review review = Review.builder().build();
-        review.softDelete();
-
-        // when
-        review.restore();
-
-        // then
-        assertTrue(!review.isDeleted());
-    }
 }

--- a/src/test/java/com/fasttime/domain/review/unit/service/BatchSchedulerTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/service/BatchSchedulerTest.java
@@ -1,0 +1,40 @@
+package com.fasttime.domain.review.unit.service;
+
+import com.fasttime.domain.review.service.BatchScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+
+import static org.mockito.Mockito.*;
+
+class BatchSchedulerTest {
+
+    @Mock
+    private JobLauncher jobLauncher;
+    @Mock
+    private Job deleteOldReviewsJob;
+
+    @InjectMocks
+    private BatchScheduler batchScheduler;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void runDeleteOldReviewsJob() throws Exception {
+        when(jobLauncher.run(deleteOldReviewsJob, new JobParameters())).thenReturn(
+            new JobExecution(0L));
+
+        batchScheduler.runDeleteOldReviewsJob();
+
+        verify(jobLauncher).run(deleteOldReviewsJob, new JobParameters());
+    }
+}


### PR DESCRIPTION
# ⭐[Feature] 리뷰 도메인 리팩토링
## 리뷰 재등록 로직 변경
**문제 사항 :**
 - 기존에는 리뷰 삭제 후 리뷰를 재등록하면 삭제된 리뷰를 복구하는 방식
 - 삭제된 리뷰를 보관할 필요성이 생김(삭제 리뷰 수정 x)
  
**변경 사항 :**
 - findByMemberId을 list 형식으로 변경
 - 리뷰 재등록시 새로운 리뷰 정보를 등록하는 방식으로 로직 수정
 - Review엔터티에 restore 제거(더 이상 사용하지 않음)
----------------------

## 리뷰 삭제 batch 적용
**문제 사항 :**
 - 삭제한 리뷰를 7일 이후에 데이터 베이스에서 삭제하도록 기획 변경
 
**변경 사항 :**
 - spring batch를 이용하여 새벽 3시에 삭제된지 7일 이후의 soft delete된 리뷰 db에서 삭제
 - 테스트 코드 추가


- #191
- #219 