### PR TITLE
Batch 기능을 사용하여, 레퍼런스 크롤링 및 상태 변경을 자동화 한다.

### DIFF
--- a/src/main/java/com/fasttime/domain/reference/repository/ActivityCustomRepository.java
+++ b/src/main/java/com/fasttime/domain/reference/repository/ActivityCustomRepository.java
@@ -2,6 +2,8 @@ package com.fasttime.domain.reference.repository;
 
 import com.fasttime.domain.reference.dto.request.ReferenceSearchRequestDto;
 import com.fasttime.domain.reference.entity.Activity;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,4 +13,6 @@ public interface ActivityCustomRepository {
         ReferenceSearchRequestDto referenceSearchRequestDto,
         Pageable pageable
     );
+
+    List<Activity> findAllByRecruitmentStart(LocalDate now);
 }

--- a/src/main/java/com/fasttime/domain/reference/repository/ActivityCustomRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/reference/repository/ActivityCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,14 @@ public class ActivityCustomRepositoryImpl implements ActivityCustomRepository {
             .where(createSearchConditionsBuilder(referenceSearchRequestDto));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public List<Activity> findAllByRecruitmentStart(LocalDate now) {
+        return queryFactory.selectFrom(qActivity)
+            .where(qActivity.status.eq(RecruitmentStatus.BEFORE)
+                .and(qActivity.startDate.goe(now)))
+            .fetch();
     }
 
     private BooleanBuilder createSearchConditionsBuilder(

--- a/src/main/java/com/fasttime/domain/reference/repository/CompetitionCustomRepository.java
+++ b/src/main/java/com/fasttime/domain/reference/repository/CompetitionCustomRepository.java
@@ -1,8 +1,9 @@
 package com.fasttime.domain.reference.repository;
 
 import com.fasttime.domain.reference.dto.request.ReferenceSearchRequestDto;
-import com.fasttime.domain.reference.entity.Activity;
 import com.fasttime.domain.reference.entity.Competition;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,4 +13,6 @@ public interface CompetitionCustomRepository {
         ReferenceSearchRequestDto referenceSearchRequestDto,
         Pageable pageable
     );
+
+    List<Competition> findAllByRecruitmentStart(LocalDate now);
 }

--- a/src/main/java/com/fasttime/domain/reference/repository/CompetitionCustomRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/reference/repository/CompetitionCustomRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,14 @@ public class CompetitionCustomRepositoryImpl implements CompetitionCustomReposit
             .where(createSearchConditionsBuilder(referenceSearchRequestDto));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public List<Competition> findAllByRecruitmentStart(LocalDate now) {
+        return queryFactory.selectFrom(qCompetition)
+            .where(qCompetition.status.eq(RecruitmentStatus.BEFORE)
+                .and(qCompetition.startDate.goe(now)))
+            .fetch();
     }
 
     private BooleanBuilder createSearchConditionsBuilder(

--- a/src/main/java/com/fasttime/domain/reference/service/CrawlingService.java
+++ b/src/main/java/com/fasttime/domain/reference/service/CrawlingService.java
@@ -32,14 +32,12 @@ public class CrawlingService {
     private final String activityBaseUrl = "https://linkareer.com/list/activity?filterBy_interestIDs=13&filterType=INTEREST&orderBy_direction=DESC&orderBy_field=CREATED_AT&page=";
     private final String competitionBaseUrl = "https://linkareer.com/list/contest?filterBy_categoryIDs=35&filterType=CATEGORY&orderBy_direction=DESC&orderBy_field=CREATED_AT&page=";
 
-    @Scheduled(cron = "0 0 0 * * *")
     public void updateNewCompetition() throws InterruptedException {
         WebDriver chromeDriver = webDriverUtil.getChromeDriver();
         searchNewReference(1, chromeDriver, SearchCrawling.COMPETITION);
         chromeDriver.quit();
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
     public void updateNewActivity() throws InterruptedException {
         WebDriver chromeDriver = webDriverUtil.getChromeDriver();
         searchNewReference(1, chromeDriver, SearchCrawling.ACTIVITY);
@@ -47,7 +45,6 @@ public class CrawlingService {
         chromeDriver.quit();
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
     public void updateDoneCompetition() throws InterruptedException {
         WebDriver chromeDriver = webDriverUtil.getChromeDriver();
         List<Integer> pages = initPage(chromeDriver, SearchCrawling.COMPETITION);
@@ -65,7 +62,6 @@ public class CrawlingService {
         }
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
     public void updateDoneActivity() throws InterruptedException {
         WebDriver chromeDriver = webDriverUtil.getChromeDriver();
         List<Integer> pages = initPage(chromeDriver, SearchCrawling.ACTIVITY);

--- a/src/main/java/com/fasttime/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/fasttime/global/batch/scheduler/BatchScheduler.java
@@ -1,4 +1,4 @@
-package com.fasttime.domain.review.service;
+package com.fasttime.global.batch.scheduler;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecutionException;
@@ -12,14 +12,28 @@ public class BatchScheduler {
 
     private final JobLauncher jobLauncher;
     private final Job deleteOldReviewsJob;
+    private final Job updateReferenceJob;
+    private final Job updateReferenceStatusJob;
 
-    public BatchScheduler(JobLauncher jobLauncher, Job deleteOldReviewsJob) {
+    public BatchScheduler(JobLauncher jobLauncher, Job deleteOldReviewsJob, Job updateReferenceJob) {
         this.jobLauncher = jobLauncher;
         this.deleteOldReviewsJob = deleteOldReviewsJob;
+        this.updateReferenceJob = updateReferenceJob;
+        this.updateReferenceStatusJob = updateReferenceJob;
     }
 
     @Scheduled(cron = "0 0 3 * * *")
     public void runDeleteOldReviewsJob() throws JobExecutionException {
         jobLauncher.run(deleteOldReviewsJob, new JobParameters());
+    }
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void runUpdateReferenceStatusJob() throws JobExecutionException {
+        jobLauncher.run(updateReferenceStatusJob, new JobParameters());
+    }
+
+    @Scheduled(cron = "0 30 2 * * *")
+    public void runUpdateReferenceJob() throws JobExecutionException {
+        jobLauncher.run(updateReferenceJob, new JobParameters());
     }
 }

--- a/src/main/java/com/fasttime/global/batch/tasklet/DeleteOldReviewsTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/DeleteOldReviewsTasklet.java
@@ -1,4 +1,4 @@
-package com.fasttime.domain.review.service;
+package com.fasttime.global.batch.tasklet;
 
 import com.fasttime.domain.review.repository.ReviewRepository;
 import java.time.LocalDateTime;

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateActivityStatusTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateActivityStatusTasklet.java
@@ -1,0 +1,32 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.reference.entity.Activity;
+import com.fasttime.domain.reference.entity.RecruitmentStatus;
+import com.fasttime.domain.reference.repository.ActivityRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateActivityStatusTasklet implements Tasklet {
+
+    private final ActivityRepository activityRepository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        log.info("모집이 시작한 대외활동 체크 Tasklet 시작");
+        List<Activity> activities = activityRepository.findAllByRecruitmentStart(LocalDate.now());
+        for (Activity activity : activities) {
+            activity.statusUpdate(RecruitmentStatus.DURING);
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateCompetitionStatusTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateCompetitionStatusTasklet.java
@@ -1,0 +1,36 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.reference.entity.Competition;
+import com.fasttime.domain.reference.entity.RecruitmentStatus;
+import com.fasttime.domain.reference.repository.CompetitionRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateCompetitionStatusTasklet implements Tasklet {
+
+    private final CompetitionRepository competitionRepository;
+
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        log.info("모집이 시작한 공모전 체크 Tasklet 시작");
+        List<Competition> competitions = competitionRepository.findAllByRecruitmentStart(
+            LocalDate.now());
+        for (Competition competition : competitions) {
+            competition.statusUpdate(RecruitmentStatus.DURING);
+        }
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateDoneActivityTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateDoneActivityTasklet.java
@@ -1,0 +1,27 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.reference.service.CrawlingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateDoneActivityTasklet implements Tasklet {
+
+    private final CrawlingService crawlingService;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
+        throws InterruptedException {
+        log.info("모집이 끝난 대외활동 크롤링 Tasklet 시작");
+        crawlingService.updateDoneActivity();
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateDoneCompetitionTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateDoneCompetitionTasklet.java
@@ -1,0 +1,27 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.reference.service.CrawlingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateDoneCompetitionTasklet implements Tasklet {
+
+    private final CrawlingService crawlingService;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
+        throws InterruptedException {
+        log.info("모집이 끝난 공모전 크롤링 Tasklet 시작");
+        crawlingService.updateDoneCompetition();
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateNewActivityTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateNewActivityTasklet.java
@@ -1,0 +1,27 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.reference.service.CrawlingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateNewActivityTasklet implements Tasklet {
+
+    private final CrawlingService crawlingService;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
+        throws InterruptedException {
+        log.info("새롭게 등록된 대외활동 크롤링 Tasklet 시작");
+        crawlingService.updateNewActivity();
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateNewCompetitionTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateNewCompetitionTasklet.java
@@ -1,0 +1,27 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.reference.service.CrawlingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateNewCompetitionTasklet implements Tasklet {
+
+    private final CrawlingService crawlingService;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
+        throws InterruptedException {
+        log.info("새롭게 등록된 공모전 크롤링 Tasklet 시작");
+        crawlingService.updateNewCompetition();
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/config/BatchConfig.java
+++ b/src/main/java/com/fasttime/global/config/BatchConfig.java
@@ -110,5 +110,4 @@ public class BatchConfig {
             .tasklet(tasklet,transactionManager)
             .build();
     }
-
 }

--- a/src/main/java/com/fasttime/global/config/BatchConfig.java
+++ b/src/main/java/com/fasttime/global/config/BatchConfig.java
@@ -1,7 +1,13 @@
 package com.fasttime.global.config;
 
 import com.fasttime.domain.review.repository.ReviewRepository;
-import com.fasttime.domain.review.service.DeleteOldReviewsTasklet;
+import com.fasttime.global.batch.tasklet.DeleteOldReviewsTasklet;
+import com.fasttime.global.batch.tasklet.UpdateActivityStatusTasklet;
+import com.fasttime.global.batch.tasklet.UpdateCompetitionStatusTasklet;
+import com.fasttime.global.batch.tasklet.UpdateDoneActivityTasklet;
+import com.fasttime.global.batch.tasklet.UpdateDoneCompetitionTasklet;
+import com.fasttime.global.batch.tasklet.UpdateNewActivityTasklet;
+import com.fasttime.global.batch.tasklet.UpdateNewCompetitionTasklet;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -31,8 +37,78 @@ public class BatchConfig {
             .build();
     }
 
+
     @Bean
     public DeleteOldReviewsTasklet deleteOldReviewsTasklet(ReviewRepository reviewRepository) {
         return new DeleteOldReviewsTasklet(reviewRepository);
     }
+
+    @Bean
+    public Job updateReferenceStatusJob(JobRepository jobRepository, Step updateActivityStatusStep,
+        Step updateCompetitionStatusStep) {
+        return new JobBuilder("updateReferenceStatusJob", jobRepository)
+            .start(updateActivityStatusStep)
+            .next(updateCompetitionStatusStep)
+            .build();
+    }
+
+    @Bean
+    public Job updateReferenceJob(JobRepository jobRepository, Step updateNewActivityStep,
+        Step updateNewCompetitionStep, Step updateDoneActivityStep, Step updateDoneCompetitionStep) {
+        return new JobBuilder("updateReferenceJob", jobRepository)
+            .start(updateNewActivityStep)
+            .next(updateNewCompetitionStep)
+            .next(updateDoneActivityStep)
+            .next(updateDoneCompetitionStep)
+            .build();
+    }
+
+    @Bean
+    public Step updateActivityStatusStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, UpdateActivityStatusTasklet tasklet){
+        return new StepBuilder("updateActivityStatusStep", jobRepository)
+            .tasklet(tasklet,transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Step updateCompetitionStatusStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, UpdateCompetitionStatusTasklet tasklet){
+        return new StepBuilder("updateCompetitionStatusStep", jobRepository)
+            .tasklet(tasklet,transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Step updateNewActivityStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, UpdateNewActivityTasklet tasklet){
+        return new StepBuilder("updateNewActivityStep", jobRepository)
+            .tasklet(tasklet,transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Step updateNewCompetitionStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, UpdateNewCompetitionTasklet tasklet){
+        return new StepBuilder("updateNewCompetitionStep", jobRepository)
+            .tasklet(tasklet,transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Step updateDoneActivityStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, UpdateDoneActivityTasklet tasklet){
+        return new StepBuilder("updateDoneActivityStep", jobRepository)
+            .tasklet(tasklet,transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Step updateDoneCompetitionStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager, UpdateDoneCompetitionTasklet tasklet){
+        return new StepBuilder("updateDoneCompetitionStep", jobRepository)
+            .tasklet(tasklet,transactionManager)
+            .build();
+    }
+
 }

--- a/src/test/java/com/fasttime/domain/review/unit/service/BatchSchedulerTest.java
+++ b/src/test/java/com/fasttime/domain/review/unit/service/BatchSchedulerTest.java
@@ -1,6 +1,6 @@
 package com.fasttime.domain.review.unit.service;
 
-import com.fasttime.domain.review.service.BatchScheduler;
+import com.fasttime.global.batch.scheduler.BatchScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
# Pull Request 요약

- 모집이 끝난 레퍼런스와 새롭게 등록된 레퍼런스를 크롤링 해오는 코드를 Batch 기능을 통해, 자동화하였습니다.
- 모집이 시작한 레퍼런스의 상태 값을 변경하는 코드를 Batch 기능을 통해, 자동화하였습니다.
- Batch 기능 확장으로 인한,  혜미님이 만들어주신 BatchScheduler, DeleteOldReviewsTasklet의 패키지를 변경 하였습니다.

## 변경 사항

- 하루에 한 번, 모집이 끝난 레퍼런스와 새롭게 등록된 레퍼런스를 크롤링
- 하루에 한 번, 모집이 시작한 레퍼런스의 상태 값을 변경
- global에 batch 패키지 추가

## 관련 이슈

- #198 

## 개발 유형

- [x] 새로운 기능 개발
- [x] 리팩토링


## 작업 기간

- 작업 시작일: (2024-03-08)
- 작업 종료일: (2024-03-08)

