### PR TITLE
[fix] @Qualifier로 주입해야 할 빈 객체 한정

### DIFF
--- a/src/main/java/com/fasttime/global/config/BatchConfig.java
+++ b/src/main/java/com/fasttime/global/config/BatchConfig.java
@@ -12,18 +12,20 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.batch.core.repository.JobRepository;
 
 @Configuration
 @EnableBatchProcessing
 public class BatchConfig {
 
     @Bean
-    public Job deleteOldReviewsJob(JobRepository jobRepository, Step deleteOldReviewsStep) {
+    public Job deleteOldReviewsJob(JobRepository jobRepository,
+        @Qualifier("deleteOldReviewsStep") Step deleteOldReviewsStep) {
         return new JobBuilder("deleteOldReviewsJob", jobRepository)
             .start(deleteOldReviewsStep)
             .build();
@@ -37,15 +39,15 @@ public class BatchConfig {
             .build();
     }
 
-
     @Bean
     public DeleteOldReviewsTasklet deleteOldReviewsTasklet(ReviewRepository reviewRepository) {
         return new DeleteOldReviewsTasklet(reviewRepository);
     }
 
     @Bean
-    public Job updateReferenceStatusJob(JobRepository jobRepository, Step updateActivityStatusStep,
-        Step updateCompetitionStatusStep) {
+    public Job updateReferenceStatusJob(JobRepository jobRepository,
+        @Qualifier("updateActivityStatusStep") Step updateActivityStatusStep,
+        @Qualifier("updateCompetitionStatusStep") Step updateCompetitionStatusStep) {
         return new JobBuilder("updateReferenceStatusJob", jobRepository)
             .start(updateActivityStatusStep)
             .next(updateCompetitionStatusStep)
@@ -53,8 +55,11 @@ public class BatchConfig {
     }
 
     @Bean
-    public Job updateReferenceJob(JobRepository jobRepository, Step updateNewActivityStep,
-        Step updateNewCompetitionStep, Step updateDoneActivityStep, Step updateDoneCompetitionStep) {
+    public Job updateReferenceJob(JobRepository jobRepository,
+        @Qualifier("updateNewActivityStep") Step updateNewActivityStep,
+        @Qualifier("updateNewCompetitionStep") Step updateNewCompetitionStep,
+        @Qualifier("updateDoneActivityStep") Step updateDoneActivityStep,
+        @Qualifier("updateDoneCompetitionStep") Step updateDoneCompetitionStep) {
         return new JobBuilder("updateReferenceJob", jobRepository)
             .start(updateNewActivityStep)
             .next(updateNewCompetitionStep)
@@ -65,49 +70,49 @@ public class BatchConfig {
 
     @Bean
     public Step updateActivityStatusStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateActivityStatusTasklet tasklet){
+        PlatformTransactionManager transactionManager, UpdateActivityStatusTasklet tasklet) {
         return new StepBuilder("updateActivityStatusStep", jobRepository)
-            .tasklet(tasklet,transactionManager)
+            .tasklet(tasklet, transactionManager)
             .build();
     }
 
     @Bean
     public Step updateCompetitionStatusStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateCompetitionStatusTasklet tasklet){
+        PlatformTransactionManager transactionManager, UpdateCompetitionStatusTasklet tasklet) {
         return new StepBuilder("updateCompetitionStatusStep", jobRepository)
-            .tasklet(tasklet,transactionManager)
+            .tasklet(tasklet, transactionManager)
             .build();
     }
 
     @Bean
     public Step updateNewActivityStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateNewActivityTasklet tasklet){
+        PlatformTransactionManager transactionManager, UpdateNewActivityTasklet tasklet) {
         return new StepBuilder("updateNewActivityStep", jobRepository)
-            .tasklet(tasklet,transactionManager)
+            .tasklet(tasklet, transactionManager)
             .build();
     }
 
     @Bean
     public Step updateNewCompetitionStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateNewCompetitionTasklet tasklet){
+        PlatformTransactionManager transactionManager, UpdateNewCompetitionTasklet tasklet) {
         return new StepBuilder("updateNewCompetitionStep", jobRepository)
-            .tasklet(tasklet,transactionManager)
+            .tasklet(tasklet, transactionManager)
             .build();
     }
 
     @Bean
     public Step updateDoneActivityStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateDoneActivityTasklet tasklet){
+        PlatformTransactionManager transactionManager, UpdateDoneActivityTasklet tasklet) {
         return new StepBuilder("updateDoneActivityStep", jobRepository)
-            .tasklet(tasklet,transactionManager)
+            .tasklet(tasklet, transactionManager)
             .build();
     }
 
     @Bean
     public Step updateDoneCompetitionStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateDoneCompetitionTasklet tasklet){
+        PlatformTransactionManager transactionManager, UpdateDoneCompetitionTasklet tasklet) {
         return new StepBuilder("updateDoneCompetitionStep", jobRepository)
-            .tasklet(tasklet,transactionManager)
+            .tasklet(tasklet, transactionManager)
             .build();
     }
 }


### PR DESCRIPTION
# Pull Request 요약

- 같은 타입의 빈이 여러 개여서 발생한 Required single bean, but n were found 에러 해결했습니다. 
- 자세한 내용은 하단에 기재한 포스트 바로가기 링크에서 확인 바랍니다. 

## 변경 사항

- BatchConfig 클래스 내부의 빈 생성 메서드에 @Qualifier를 추가해 주입해야 할 빈을 한정시켰습니다. 

## 관련 이슈

- #233 

## 개발 유형

- [x] 버그 수정

## 작업 기간

- 작업 시작일: (2024-04-04)
- 작업 종료일: (2024-04-04)

## 유의사항

- 해당 사항 없음

## 참고문헌

- [트러블 슈팅 포스트 바로가기](https://velog.io/@uijeong/Required-a-single-bean-but-N-were-found-error)

closes #233 
