### PR TITLE
[feat] 스터디 게시판 CRUD 기능을 추가한다.

### DIFF
--- a/src/main/java/com/fasttime/domain/study/controller/StudyController.java
+++ b/src/main/java/com/fasttime/domain/study/controller/StudyController.java
@@ -1,0 +1,81 @@
+package com.fasttime.domain.study.controller;
+
+import com.fasttime.domain.study.dto.StudyCreateRequest;
+import com.fasttime.domain.study.dto.StudyPageRequestService;
+import com.fasttime.domain.study.dto.StudyPageResponse;
+import com.fasttime.domain.study.dto.StudyResponse;
+import com.fasttime.domain.study.dto.StudyUpdateRequest;
+import com.fasttime.domain.study.service.StudyService;
+import com.fasttime.global.util.ResponseDTO;
+import com.fasttime.global.util.SecurityUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/studies")
+@RequiredArgsConstructor
+public class StudyController {
+
+    private final StudyService studyService;
+    private final SecurityUtil securityUtil;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<String>> createStudy(
+        @RequestBody @Valid StudyCreateRequest request) {
+        StudyResponse response = studyService.createStudy(
+            securityUtil.getCurrentMemberId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ResponseDTO.res(HttpStatus.CREATED, "스터디 게시판 생성 성공",
+                "/api/v2/studies/%d".formatted(response.id())));
+    }
+
+    @PutMapping("/{studyId}")
+    public ResponseEntity<ResponseDTO<StudyResponse>> updateStudy(
+        @PathVariable Long studyId, @RequestBody @Valid StudyUpdateRequest request) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK,
+                studyService.updateStudy(studyId, securityUtil.getCurrentMemberId(), request)));
+    }
+
+    @DeleteMapping("/{studyId}")
+    public ResponseEntity<ResponseDTO<StudyResponse>> deleteStudy(@PathVariable Long studyId) {
+        studyService.deleteStudy(studyId,securityUtil.getCurrentMemberId());
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK, null, null));
+    }
+
+    @GetMapping("/{studyId}")
+    public ResponseEntity<ResponseDTO<StudyResponse>> getStudy(@PathVariable Long studyId) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK, studyService.getStudy(studyId)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<StudyPageResponse>> getStudies(
+        @RequestParam(defaultValue = "10") int pageSize,
+        @RequestParam(defaultValue = "createdAt") String orderBy,
+        @RequestParam(defaultValue = "0") int page
+    ) {
+        StudyPageResponse studyPageResponse = studyService.searchStudies(
+            StudyPageRequestService.builder()
+                .pageSize(pageSize)
+                .page(page)
+                .orderBy(orderBy)
+                .build().toPageable());
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK, studyPageResponse));
+    }
+
+}

--- a/src/main/java/com/fasttime/domain/study/dto/StudyCreateRequest.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyCreateRequest.java
@@ -1,0 +1,28 @@
+package com.fasttime.domain.study.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record StudyCreateRequest(
+    @NotBlank
+    String title,
+    @NotBlank
+    String content,
+    @NotBlank
+    String skill,
+    @NotNull
+    int total,
+    @NotBlank
+    LocalDate recruitmentEnd,
+    @NotBlank
+    LocalDate progressStart,
+    @NotBlank
+    LocalDate progressEnd,
+    @NotBlank
+    String contact,
+    List<Long> categoryIds) {
+}

--- a/src/main/java/com/fasttime/domain/study/dto/StudyPageRequestService.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyPageRequestService.java
@@ -1,0 +1,33 @@
+package com.fasttime.domain.study.dto;
+
+import lombok.Builder;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+@Builder
+public record StudyPageRequestService(
+    String orderBy,
+    int page,
+    int pageSize
+) {
+
+    @Builder
+    public StudyPageRequestService(
+        String orderBy,
+        int page,
+        int pageSize
+    ) {
+        this.orderBy = orderBy;
+        this.page = Math.max(page, 0);
+        this.pageSize = pageSize > 20 ? 10 : pageSize;
+    }
+
+    public PageRequest toPageable() {
+        return switch (orderBy) {
+            case "applicant" -> PageRequest.of(page, pageSize, Sort.by(Direction.DESC, "applicant"));
+            case "latest" -> PageRequest.of(page, pageSize, Sort.by(Direction.DESC, "createdAt"));
+            default -> PageRequest.of(page, pageSize);
+        };
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/dto/StudyPageResponse.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyPageResponse.java
@@ -1,0 +1,24 @@
+package com.fasttime.domain.study.dto;
+
+import com.fasttime.domain.study.entity.Study;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+public record StudyPageResponse(
+    int totalPages,
+    Boolean isLastPage,
+    long totalStudies,
+    List<StudyResponse> studies
+) {
+
+    public static StudyPageResponse of(Page<Study> studyPage, List<StudyResponse> studies) {
+        return StudyPageResponse.builder()
+            .totalPages(studyPage.getTotalPages())
+            .isLastPage(studyPage.isLast())
+            .totalStudies(studyPage.getTotalElements())
+            .studies(studies)
+            .build();
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/dto/StudyResponse.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyResponse.java
@@ -1,0 +1,25 @@
+package com.fasttime.domain.study.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record StudyResponse(
+    Long id,
+    String title,
+    String content,
+    String skill,
+    int total,
+    int current,
+    int applicant,
+    LocalDate recruitmentStart,
+    LocalDate recruitmentEnd,
+    LocalDate progressStart,
+    LocalDate progressEnd,
+    String contact,
+    String nickname,
+    List<String> categories
+) {
+
+}

--- a/src/main/java/com/fasttime/domain/study/dto/StudyUpdateRequest.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.fasttime.domain.study.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+public record StudyUpdateRequest(
+    @NotBlank
+    String title,
+    @NotBlank
+    String content,
+    @NotBlank
+    String skill,
+    @NotNull
+    int total,
+    @NotBlank
+    LocalDate recruitmentEnd,
+    @NotBlank
+    LocalDate progressStart,
+    @NotBlank
+    LocalDate progressEnd,
+    @NotBlank
+    String contact,
+    List<Long> categoryIds) {
+
+}

--- a/src/main/java/com/fasttime/domain/study/entity/Category.java
+++ b/src/main/java/com/fasttime/domain/study/entity/Category.java
@@ -21,6 +21,6 @@ public class Category {
 
     private String name;
 
-    @OneToMany(mappedBy = "study_id",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "category",cascade = CascadeType.ALL)
     private List<StudyCategory> studyCategories;
 }

--- a/src/main/java/com/fasttime/domain/study/entity/Category.java
+++ b/src/main/java/com/fasttime/domain/study/entity/Category.java
@@ -1,0 +1,26 @@
+package com.fasttime.domain.study.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "study_id",cascade = CascadeType.ALL)
+    private List<StudyCategory> studyCategories;
+}

--- a/src/main/java/com/fasttime/domain/study/entity/Study.java
+++ b/src/main/java/com/fasttime/domain/study/entity/Study.java
@@ -1,0 +1,117 @@
+package com.fasttime.domain.study.entity;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.global.common.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Study extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private StudyState studyState;
+
+    private String skill;
+    /* 총 인원 수 */
+    private int total;
+    /* 현재 인원 */
+    private int current;
+    /* 지원자 수 */
+    private int applicant;
+    /* 모집 시작 */
+    private LocalDate recruitmentStart;
+    /* 모집 마감 */
+    private LocalDate recruitmentEnd;
+    /* 스터디 시작 */
+    private LocalDate progressStart;
+    /* 스터디 종료 */
+    private LocalDate progressEnd;
+    /* 연락처 */
+    private String contact;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "study_id",cascade = CascadeType.ALL)
+    private List<StudyCategory> studyCategories;
+
+    @Builder
+    public Study(Long id, String title, String content, String skill, StudyState studyState,
+        int total, int current, int applicant, LocalDate recruitmentStart,
+        LocalDate recruitmentEnd, LocalDate progressStart,
+        LocalDate progressEnd, String contact, Member member, List<StudyCategory> studyCategories) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.studyState = studyState;
+        this.skill = skill;
+        this.total = total;
+        this.current = current;
+        this.applicant = applicant;
+        this.recruitmentStart = recruitmentStart;
+        this.recruitmentEnd = recruitmentEnd;
+        this.progressStart = progressStart;
+        this.progressEnd = progressEnd;
+        this.contact = contact;
+        this.member = member;
+    }
+
+    public static Study createNewStudy(String title, String content, String skill, int total,
+        LocalDate recruitmentEnd, LocalDate progressStart, LocalDate progressEnd,
+        String contact, Member member) {
+        return Study.builder().title(title)
+            .content(content)
+            .studyState(StudyState.DURING)
+            .skill(skill)
+            .total(total)
+            .current(0)
+            .applicant(0)
+            .recruitmentStart(LocalDate.now())
+            .recruitmentEnd(recruitmentEnd)
+            .progressStart(progressStart)
+            .progressEnd(progressEnd)
+            .contact(contact)
+            .member(member).build();
+    }
+
+    public void updateStudy(String title, String content, String skill, int total,
+        LocalDate recruitmentEnd, LocalDate progressStart, LocalDate progressEnd, String contact) {
+        this.title = title;
+        this.content = content;
+        this.skill = skill;
+        this.total = total;
+        this.recruitmentEnd = recruitmentEnd;
+        this.progressStart = progressStart;
+        this.progressEnd = progressEnd;
+        this.contact = contact;
+
+    }
+
+    @Override
+    public void delete(LocalDateTime currentTime) {
+        super.delete(currentTime);
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/entity/Study.java
+++ b/src/main/java/com/fasttime/domain/study/entity/Study.java
@@ -55,7 +55,7 @@ public class Study extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "study_id",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "study",cascade = CascadeType.ALL)
     private List<StudyCategory> studyCategories;
 
     @Builder

--- a/src/main/java/com/fasttime/domain/study/entity/StudyCategory.java
+++ b/src/main/java/com/fasttime/domain/study/entity/StudyCategory.java
@@ -1,0 +1,37 @@
+package com.fasttime.domain.study.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    public StudyCategory(Long id, Study study, Category category) {
+        this.id = id;
+        this.study = study;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/entity/StudyState.java
+++ b/src/main/java/com/fasttime/domain/study/entity/StudyState.java
@@ -1,0 +1,5 @@
+package com.fasttime.domain.study.entity;
+
+public enum StudyState {
+    DURING, CLOSED
+}

--- a/src/main/java/com/fasttime/domain/study/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/study/exception/CategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.study.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class CategoryNotFoundException extends ApplicationException {
+
+    public CategoryNotFoundException() {
+        super(ErrorCode.CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/exception/NotStudyWriterException.java
+++ b/src/main/java/com/fasttime/domain/study/exception/NotStudyWriterException.java
@@ -1,0 +1,15 @@
+package com.fasttime.domain.study.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class NotStudyWriterException extends ApplicationException {
+
+    public NotStudyWriterException() {
+        super(ErrorCode.HAS_NO_PERMISSION_WITH_THIS_STUDY);
+    }
+
+    public NotStudyWriterException(String message) {
+        super(ErrorCode.HAS_NO_PERMISSION_WITH_THIS_STUDY, message);
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/exception/StudyNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/study/exception/StudyNotFoundException.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.study.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class StudyNotFoundException extends ApplicationException {
+
+    public StudyNotFoundException() {
+        super(ErrorCode.STUDY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/repository/CategoryRepository.java
+++ b/src/main/java/com/fasttime/domain/study/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.fasttime.domain.study.repository;
+
+import com.fasttime.domain.study.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/com/fasttime/domain/study/repository/StudyCategoryRepository.java
+++ b/src/main/java/com/fasttime/domain/study/repository/StudyCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.study.repository;
+
+import com.fasttime.domain.study.entity.Study;
+import com.fasttime.domain.study.entity.StudyCategory;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyCategoryRepository extends JpaRepository<StudyCategory, Long> {
+
+    List<StudyCategory> findAllByStudy(Study study);
+}

--- a/src/main/java/com/fasttime/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/fasttime/domain/study/repository/StudyRepository.java
@@ -1,0 +1,7 @@
+package com.fasttime.domain.study.repository;
+
+import com.fasttime.domain.study.entity.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRepository extends JpaRepository<Study, Long>,StudyRepositoryCustom {
+}

--- a/src/main/java/com/fasttime/domain/study/repository/StudyRepositoryCustom.java
+++ b/src/main/java/com/fasttime/domain/study/repository/StudyRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.study.repository;
+
+import com.fasttime.domain.study.dto.StudyPageRequestService;
+import com.fasttime.domain.study.entity.Study;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface StudyRepositoryCustom {
+
+    Page<Study> search(Pageable pageable);
+
+}

--- a/src/main/java/com/fasttime/domain/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/study/repository/StudyRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.fasttime.domain.study.repository;
+
+import com.fasttime.domain.study.entity.QStudy;
+import com.fasttime.domain.study.entity.Study;
+import com.fasttime.global.util.QueryDslUtil;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+
+
+public class StudyRepositoryImpl implements StudyRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QStudy study = QStudy.study;
+
+    public StudyRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public Page<Study> search(Pageable pageable) {
+        List<Study> studies = jpaQueryFactory.selectFrom(study)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new)).fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+            .select(study.count())
+            .from(study);
+
+        return PageableExecutionUtils.getPage(studies, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new LinkedList<>();
+        if (!pageable.getSort().isEmpty()) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                switch (order.getProperty()) {
+                    case "applicant":
+                        orders.add(QueryDslUtil.getSortedColumn(direction, study, "applicant"));
+                    case "createdAt":
+                        orders.add(QueryDslUtil.getSortedColumn(direction, study, "createdAt"));
+                    default:
+                        orders.add(QueryDslUtil.getSortedColumn(Order.DESC, study, "createdAt"));
+                }
+            }
+        }
+
+        return orders;
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/service/CategoryService.java
+++ b/src/main/java/com/fasttime/domain/study/service/CategoryService.java
@@ -1,0 +1,21 @@
+package com.fasttime.domain.study.service;
+
+import com.fasttime.domain.study.entity.Category;
+import com.fasttime.domain.study.exception.CategoryNotFoundException;
+import com.fasttime.domain.study.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public Category getCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+            .orElseThrow(CategoryNotFoundException::new);
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/service/StudyCategoryService.java
+++ b/src/main/java/com/fasttime/domain/study/service/StudyCategoryService.java
@@ -1,0 +1,42 @@
+package com.fasttime.domain.study.service;
+
+import com.fasttime.domain.study.entity.Study;
+import com.fasttime.domain.study.entity.StudyCategory;
+import com.fasttime.domain.study.repository.StudyCategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudyCategoryService {
+
+    private final StudyCategoryRepository studyCategoryRepository;
+    private final CategoryService categoryService;
+
+    @Transactional
+    public void createCategory(Study study, List<Long> categoryIds) {
+        categoryIds.stream()
+            .map(categoryService::getCategory)
+            .forEach(category -> studyCategoryRepository.save(
+                StudyCategory.builder()
+                    .study(study)
+                    .category(category)
+                    .build()
+            ));
+    }
+
+    @Transactional
+    public void deleteCategoryByUpdate(Study study) {
+        studyCategoryRepository.deleteAllInBatch(studyCategoryRepository.findAllByStudy(study));
+    }
+
+    public List<String> findCategoryNameByStudy(Study study) {
+        List<StudyCategory> studyCategories = studyCategoryRepository.findAllByStudy(study);
+        return studyCategories.stream()
+            .map(studyCategory -> studyCategory.getCategory().getName()).toList();
+    }
+
+}

--- a/src/main/java/com/fasttime/domain/study/service/StudyService.java
+++ b/src/main/java/com/fasttime/domain/study/service/StudyService.java
@@ -1,0 +1,116 @@
+package com.fasttime.domain.study.service;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.service.MemberService;
+import com.fasttime.domain.study.dto.StudyCreateRequest;
+import com.fasttime.domain.study.dto.StudyPageResponse;
+import com.fasttime.domain.study.dto.StudyResponse;
+import com.fasttime.domain.study.dto.StudyUpdateRequest;
+import com.fasttime.domain.study.entity.Study;
+import com.fasttime.domain.study.exception.NotStudyWriterException;
+import com.fasttime.domain.study.exception.StudyNotFoundException;
+import com.fasttime.domain.study.repository.StudyRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyService {
+
+    private final StudyRepository studyRepository;
+    private final StudyCategoryService studyCategoryService;
+    private final MemberService memberService;
+
+    @Transactional
+    public StudyResponse createStudy(Long memberId, StudyCreateRequest studyCreateRequest) {
+        Member member = memberService.getMember(memberId);
+
+        Study savedStudy = studyRepository.save(
+            Study.createNewStudy(
+                studyCreateRequest.title(), studyCreateRequest.content(),
+                studyCreateRequest.skill(), studyCreateRequest.total(),
+                studyCreateRequest.recruitmentEnd(), studyCreateRequest.progressStart(),
+                studyCreateRequest.progressEnd(), studyCreateRequest.contact(), member
+            ));
+
+        studyCategoryService.createCategory(savedStudy, studyCreateRequest.categoryIds());
+
+        return getStudyResponse(savedStudy);
+    }
+
+    @Transactional
+    public StudyResponse updateStudy(Long studyId, Long memberId, StudyUpdateRequest request) {
+        Study study = findStudyById(studyId);
+        Member member = memberService.getMember(memberId);
+        isWriter(member, study);
+
+        studyCategoryService.deleteCategoryByUpdate(study);
+        studyCategoryService.createCategory(study, request.categoryIds());
+
+        study.updateStudy(
+            request.title(), request.content(), request.skill(), request.total(),
+            request.recruitmentEnd(), request.progressStart(), request.progressEnd(),
+            request.contact()
+        );
+
+        return getStudyResponse(study);
+
+    }
+
+    @Transactional
+    public void deleteStudy(Long studyId, Long memberId) {
+        Study study = findStudyById(studyId);
+        Member member = memberService.getMember(memberId);
+        isWriter(member, study);
+        study.delete(LocalDateTime.now());
+    }
+
+    public StudyResponse getStudy(Long studyId) {
+        return getStudyResponse(findStudyById(studyId));
+    }
+
+    public StudyPageResponse searchStudies(Pageable pageable) {
+        Page<Study> studyPage = studyRepository.search(pageable);
+        List<StudyResponse> studyResponses = studyPage.getContent().stream()
+            .map(this::getStudyResponse)
+            .toList();
+        return StudyPageResponse.of(studyPage, studyResponses);
+    }
+
+    private void isWriter(Member requestMember, Study study) {
+        if (!requestMember.getId().equals(study.getMember().getId())) {
+            throw new NotStudyWriterException(String.format(
+                "This member has no auth to control this study / targetStudyId = %d, requestMemberId = %d",
+                study.getId(), requestMember.getId()));
+        }
+    }
+
+    private Study findStudyById(Long studyId) {
+        return studyRepository.findById(studyId).orElseThrow(StudyNotFoundException::new);
+    }
+
+    private StudyResponse getStudyResponse(Study study) {
+        return StudyResponse.builder()
+            .id(study.getId())
+            .title(study.getTitle())
+            .content(study.getContent())
+            .skill(study.getSkill())
+            .total(study.getTotal())
+            .current(study.getCurrent())
+            .applicant(study.getApplicant())
+            .recruitmentStart(study.getRecruitmentStart())
+            .recruitmentEnd(study.getRecruitmentEnd())
+            .progressStart(study.getProgressStart())
+            .progressEnd(study.getProgressEnd())
+            .contact(study.getContact())
+            .nickname(study.getMember().getNickname())
+            .categories(studyCategoryService.findCategoryNameByStudy(study)).build();
+    }
+
+}

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -56,6 +56,10 @@ public enum ErrorCode {
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 대외활동입니다."),
     COMPETITION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 공모전입니다."),
 
+    // STUDY
+    STUDY_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 스터디게시판입니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 스터디 분야입니다."),
+    HAS_NO_PERMISSION_WITH_THIS_STUDY(HttpStatus.UNAUTHORIZED, "해당 스터디 게시글에 대한 권한이 없습니다."),
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 

--- a/src/main/resources/db/migration/V24__Add_study_table.sql
+++ b/src/main/resources/db/migration/V24__Add_study_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE study
+(
+    id               BIGINT AUTO_INCREMENT NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    content             VARCHAR(255) NOT NULL,
+    skill               VARCHAR(255) NOT NULL,
+    total               INT          NOT NULL,
+    current             INT          NOT NULL,
+    applicant           INT          NOT NULL,
+    recruitment_start   DATE          NOT NULL,
+    recruitment_end     DATE          NOT NULL,
+    progress_start      DATE          NOT NULL,
+    progress_end        DATE          NOT NULL,
+    contact             VARCHAR(255) NOT NULL,
+    studyState          enum ('DURING','CLOSED') NOT NULL,
+    CONSTRAINT pk_study PRIMARY KEY (id)
+);
+
+ALTER TABLE study
+    ADD CONSTRAINT FK_STUDY_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (id);

--- a/src/main/resources/db/migration/V25__Add_category_table.sql
+++ b/src/main/resources/db/migration/V25__Add_category_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE category
+(
+    id               BIGINT AUTO_INCREMENT NOT NULL,
+    name               VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_category PRIMARY KEY (id)
+);

--- a/src/main/resources/db/migration/V26__Add_studyCategory_table.sql
+++ b/src/main/resources/db/migration/V26__Add_studyCategory_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE study_category
+(
+    id               BIGINT AUTO_INCREMENT NOT NULL,
+    CONSTRAINT pk_study_category PRIMARY KEY (id)
+);
+
+ALTER TABLE study_category
+    ADD CONSTRAINT FK_STUDY_CATEGORY_ON_STUDY FOREIGN KEY (study_id) REFERENCES study (id);
+
+ALTER TABLE study_category
+    ADD CONSTRAINT FK_STUDY_CATEGORY_ON_CATEGORY FOREIGN KEY (category_id) REFERENCES category (id);


### PR DESCRIPTION
# Pull Request 요약

- 스터디 게시판의 CRUD를 개발하였습니다.

## 변경 사항

- 스터디, 카테고리, 스터티 카테고리 엔티티 추가
- 스터디, 카테고리, 스터티 카테고리 Repository 추가
- 스터디, 카테고리, 스터티 카테고리 Service 추가
- 스터티 Controller 추가
- 스터티 CRUD 기능 구현
 

## 관련 이슈

- #223 
- #224 
- #225 
- #226 
- #227 

## 개발 유형

- [x] 새로운 기능 개발



## 작업 기간

- 작업 시작일: (2024--04--06)
- 작업 종료일: (2024--04--14)

## 유의사항

- 스터디 게시판 CRUD 테스트 코드와 API 명세서는 다음주 주말에 구현 예정입니다.
- 스터디 게시판에 쓰일 댓글 기능 또한, 추후 구현 예정입니다.