### PR TITLE
[Refactor] Redis를 활용해 전송된 인증코드 유효기간을 설정한다. 

### DIFF
--- a/src/docs/asciidoc/email/email-api.adoc
+++ b/src/docs/asciidoc/email/email-api.adoc
@@ -30,6 +30,8 @@ include::{snippets}/email-send-verification/response-fields.adoc[]
 
 전송 인증 코드, 입력 인증 코드가 일치하는지 비교하는 API 입니다.
 
+* 전송 받은 인증 코드의 유효시간은 5분입니다.
+
 
 === HttpRequest
 

--- a/src/main/java/com/fasttime/domain/member/exception/EmailTemplateLoadException.java
+++ b/src/main/java/com/fasttime/domain/member/exception/EmailTemplateLoadException.java
@@ -11,5 +11,4 @@ public class EmailTemplateLoadException extends ApplicationException {
 
         super(ERROR_CODE);
     }
-
 }

--- a/src/main/java/com/fasttime/domain/member/exception/VerificationCodeExpiredException.java
+++ b/src/main/java/com/fasttime/domain/member/exception/VerificationCodeExpiredException.java
@@ -1,0 +1,14 @@
+package com.fasttime.domain.member.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class VerificationCodeExpiredException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED;
+
+    public VerificationCodeExpiredException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     //EMAIL
     EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_TEMPLATE_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿 로드에 실패했습니다."),
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "인증 코드의 유효 기간이 만료되었습니다."),
 
     // MEMBER
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),


### PR DESCRIPTION
# ⭐️ [Refactor] Redis를 활용해 인증코드 만료시간을 설정한다. 

## 변경 사항

- 인증 코드 유효기간 설정을 위해 ConcurrentHashMap을 사용하는 대신 Redis를 도입하였습니다. 
Redis의 만료 기능을 활용하여 인증 코드의 자동 만료 처리를 구현하였습니다.
- RedisTemplate 활용
- 인증 코드 불일치와 인증 코드 만료를 구분하기 위해 VerificationCodeExpiredException를 추가하였습니다.

## 관련 이슈

- #242 

## 개발 유형

- [ ] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-04-16)
- 작업 종료일: (2024-04-16)


