### PR TITLE
[Refactor] 읽기전용 트랜잭션 추가

### DIFF
--- a/src/docs/asciidoc/email/email-api.adoc
+++ b/src/docs/asciidoc/email/email-api.adoc
@@ -30,6 +30,8 @@ include::{snippets}/email-send-verification/response-fields.adoc[]
 
 전송 인증 코드, 입력 인증 코드가 일치하는지 비교하는 API 입니다.
 
+* 전송 받은 인증 코드의 유효시간은 5분입니다.
+
 
 === HttpRequest
 

--- a/src/main/java/com/fasttime/domain/certification/service/CertificationService.java
+++ b/src/main/java/com/fasttime/domain/certification/service/CertificationService.java
@@ -63,6 +63,7 @@ public class CertificationService {
         return certificationRepository.save(certification);
     }
 
+    @Transactional(readOnly = true)
     public List<Certification> getCertificationsByMember(Long memberId) {
         return certificationRepository.findByMemberId(memberId);
     }
@@ -123,6 +124,7 @@ public class CertificationService {
         return certificationRepository.save(certification);
     }
 
+    @Transactional(readOnly = true)
     public Page<AllCertificationResponseDTO> getAllCertificationsByStatus(
         CertificationStatus status, Pageable pageable) {
         Page<Certification> certificationPage;

--- a/src/main/java/com/fasttime/domain/member/exception/EmailTemplateLoadException.java
+++ b/src/main/java/com/fasttime/domain/member/exception/EmailTemplateLoadException.java
@@ -11,5 +11,4 @@ public class EmailTemplateLoadException extends ApplicationException {
 
         super(ERROR_CODE);
     }
-
 }

--- a/src/main/java/com/fasttime/domain/member/exception/VerificationCodeExpiredException.java
+++ b/src/main/java/com/fasttime/domain/member/exception/VerificationCodeExpiredException.java
@@ -1,0 +1,14 @@
+package com.fasttime.domain.member.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class VerificationCodeExpiredException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED;
+
+    public VerificationCodeExpiredException() {
+
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     //EMAIL
     EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_TEMPLATE_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿 로드에 실패했습니다."),
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.GONE, "인증 코드의 유효 기간이 만료되었습니다."),
 
     // MEMBER
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),


### PR DESCRIPTION
문제 사항 :
 - 기존 클래스 레벨이 트랜잭션을 설정했지만, 조회 메서드에 읽기전용 트랜잭션을 따로 설정하지 않음.

변경 사항 :
 - 조회 메서드(getCertificationsByMember,getAllCertificationsByStatus)에 읽기 전용 트랜잭션 추가
