### PR TITLE
[feat] 스터디 CRUD, 카테고리 조회 API docs test를 추가한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     // test
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/docs/asciidoc/category/category-api.adoc
+++ b/src/docs/asciidoc/category/category-api.adoc
@@ -1,0 +1,21 @@
+= Post REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+
+[[Category-Search]]
+== 스터디 모집글 카테고리 전체 조회
+
+스터디 모집글에서 사용하는 모든 카테고리들을 조회할 수 있는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/category-get/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/category-get/http-response.adoc[]
+include::{snippets}/category-get/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -21,6 +21,8 @@ endif::[]
 === link:review/review-api.html[리뷰 API, window=blank]
 === link:reference/reference-api.html[대외활동/공모전 API, window=blank]
 === link:certification/certification-api.html[부트캠프 인증 API, window=blank]
+=== link:study/study-api.html[스터디 모집글 API, window=blank]
+=== link:category/category-api.html[스터디 모집글 카데고리 API, window=blank]
 
 
 == API Common Response

--- a/src/docs/asciidoc/study/study-api.adoc
+++ b/src/docs/asciidoc/study/study-api.adoc
@@ -1,0 +1,82 @@
+= Post REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+
+[[Post-Create]]
+== 스터디 모집글 등록
+
+회원이 스터디 모집글을 등록하는 API 입니다.
+
+
+=== HttpRequest
+
+include::{snippets}/study-create/http-request.adoc[]
+include::{snippets}/study-create/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/study-create/http-response.adoc[]
+include::{snippets}/study-create/response-fields.adoc[]
+
+[[Posts-Search]]
+== 스터디 모집 목록 조회
+
+회원이 스터디 모집글 목록을 조회하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/articles/v2/search/http-request.adoc[]
+include::{snippets}/articles/v2/search/query-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/study-search/http-response.adoc[]
+include::{snippets}/study-search/response-fields.adoc[]
+
+[[Post-Search]]
+== 스터디 모집 상세 조회
+
+회원이 스터디 모집글 상세 정보를 조회하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/study-get/http-request.adoc[]
+include::{snippets}/study-get/path-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/study-get/http-response.adoc[]
+include::{snippets}/study-get/response-fields.adoc[]
+
+[[Post-Update]]
+== 스터디 모집글 수정
+
+회원이 스터디 모집글 정보를 수정하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/study-update/http-request.adoc[]
+include::{snippets}/study-update/request-fields.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/study-update/http-response.adoc[]
+include::{snippets}/study-update/response-fields.adoc[]
+
+[[Post-Delete]]
+== 스터디 모집글 삭제
+
+회원이 스터디 모집글 정보를 삭제하는 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/study-delete/http-request.adoc[]
+include::{snippets}/study-delete/path-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/study-delete/http-response.adoc[]

--- a/src/docs/asciidoc/study/study-api.adoc
+++ b/src/docs/asciidoc/study/study-api.adoc
@@ -1,4 +1,4 @@
-= Post REST API Docs
+= Study REST API Docs
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs

--- a/src/main/java/com/fasttime/domain/study/controller/CategoryController.java
+++ b/src/main/java/com/fasttime/domain/study/controller/CategoryController.java
@@ -1,0 +1,28 @@
+package com.fasttime.domain.study.controller;
+
+
+import com.fasttime.domain.study.dto.CategoryResponse;
+import com.fasttime.domain.study.service.CategoryService;
+import com.fasttime.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<CategoryResponse>>> getAllCategories() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDTO.res(HttpStatus.OK,categoryService.getAllCategories()));
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/controller/StudyController.java
+++ b/src/main/java/com/fasttime/domain/study/controller/StudyController.java
@@ -41,19 +41,19 @@ public class StudyController {
     }
 
     @PutMapping("/{studyId}")
-    public ResponseEntity<ResponseDTO<StudyResponse>> updateStudy(
+    public ResponseEntity<ResponseDTO<Long>> updateStudy(
         @PathVariable Long studyId, @RequestBody @Valid StudyUpdateRequest request) {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseDTO.res(HttpStatus.OK,
-                studyService.updateStudy(studyId, securityUtil.getCurrentMemberId(), request)));
+                studyService.updateStudy(studyId, securityUtil.getCurrentMemberId(), request).id()));
     }
 
     @DeleteMapping("/{studyId}")
     public ResponseEntity<ResponseDTO<StudyResponse>> deleteStudy(@PathVariable Long studyId) {
         studyService.deleteStudy(studyId,securityUtil.getCurrentMemberId());
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(ResponseDTO.res(HttpStatus.OK, null, null));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .body(ResponseDTO.res(HttpStatus.NO_CONTENT, null, null));
     }
 
     @GetMapping("/{studyId}")

--- a/src/main/java/com/fasttime/domain/study/dto/CategoryResponse.java
+++ b/src/main/java/com/fasttime/domain/study/dto/CategoryResponse.java
@@ -1,0 +1,15 @@
+package com.fasttime.domain.study.dto;
+
+import com.fasttime.domain.study.entity.Category;
+import lombok.Builder;
+
+@Builder
+public record CategoryResponse(
+        Long id,
+        String name) {
+    public static CategoryResponse of(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .name(category.getName()).build();
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/dto/StudyCreateRequest.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyCreateRequest.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.study.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -16,11 +17,11 @@ public record StudyCreateRequest(
     String skill,
     @NotNull
     int total,
-    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     LocalDate recruitmentEnd,
-    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     LocalDate progressStart,
-    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     LocalDate progressEnd,
     @NotBlank
     String contact,

--- a/src/main/java/com/fasttime/domain/study/dto/StudyUpdateRequest.java
+++ b/src/main/java/com/fasttime/domain/study/dto/StudyUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.study.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -14,11 +15,11 @@ public record StudyUpdateRequest(
     String skill,
     @NotNull
     int total,
-    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     LocalDate recruitmentEnd,
-    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     LocalDate progressStart,
-    @NotBlank
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     LocalDate progressEnd,
     @NotBlank
     String contact,

--- a/src/main/java/com/fasttime/domain/study/exception/StudyDeleteException.java
+++ b/src/main/java/com/fasttime/domain/study/exception/StudyDeleteException.java
@@ -1,0 +1,10 @@
+package com.fasttime.domain.study.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class StudyDeleteException extends ApplicationException {
+    public StudyDeleteException() {
+        super(ErrorCode.STUDY_DELETED);
+    }
+}

--- a/src/main/java/com/fasttime/domain/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/study/repository/StudyRepositoryImpl.java
@@ -28,13 +28,15 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     @Override
     public Page<Study> search(Pageable pageable) {
         List<Study> studies = jpaQueryFactory.selectFrom(study)
+                .where(study.deletedAt.isNull())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new)).fetch();
 
         JPAQuery<Long> countQuery = jpaQueryFactory
             .select(study.count())
-            .from(study);
+            .from(study)
+                .where(study.deletedAt.isNull());
 
         return PageableExecutionUtils.getPage(studies, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/fasttime/domain/study/service/CategoryService.java
+++ b/src/main/java/com/fasttime/domain/study/service/CategoryService.java
@@ -1,11 +1,14 @@
 package com.fasttime.domain.study.service;
 
+import com.fasttime.domain.study.dto.CategoryResponse;
 import com.fasttime.domain.study.entity.Category;
 import com.fasttime.domain.study.exception.CategoryNotFoundException;
 import com.fasttime.domain.study.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +20,9 @@ public class CategoryService {
     public Category getCategory(Long categoryId) {
         return categoryRepository.findById(categoryId)
             .orElseThrow(CategoryNotFoundException::new);
+    }
+    public List<CategoryResponse> getAllCategories() {
+        List<Category> categories = categoryRepository.findAll();
+        return categories.stream().map(CategoryResponse::of).toList();
     }
 }

--- a/src/main/java/com/fasttime/domain/study/service/StudyService.java
+++ b/src/main/java/com/fasttime/domain/study/service/StudyService.java
@@ -8,6 +8,7 @@ import com.fasttime.domain.study.dto.StudyResponse;
 import com.fasttime.domain.study.dto.StudyUpdateRequest;
 import com.fasttime.domain.study.entity.Study;
 import com.fasttime.domain.study.exception.NotStudyWriterException;
+import com.fasttime.domain.study.exception.StudyDeleteException;
 import com.fasttime.domain.study.exception.StudyNotFoundException;
 import com.fasttime.domain.study.repository.StudyRepository;
 import java.time.LocalDateTime;
@@ -32,12 +33,12 @@ public class StudyService {
         Member member = memberService.getMember(memberId);
 
         Study savedStudy = studyRepository.save(
-            Study.createNewStudy(
-                studyCreateRequest.title(), studyCreateRequest.content(),
-                studyCreateRequest.skill(), studyCreateRequest.total(),
-                studyCreateRequest.recruitmentEnd(), studyCreateRequest.progressStart(),
-                studyCreateRequest.progressEnd(), studyCreateRequest.contact(), member
-            ));
+                Study.createNewStudy(
+                        studyCreateRequest.title(), studyCreateRequest.content(),
+                        studyCreateRequest.skill(), studyCreateRequest.total(),
+                        studyCreateRequest.recruitmentEnd(), studyCreateRequest.progressStart(),
+                        studyCreateRequest.progressEnd(), studyCreateRequest.contact(), member
+                ));
 
         studyCategoryService.createCategory(savedStudy, studyCreateRequest.categoryIds());
 
@@ -92,7 +93,11 @@ public class StudyService {
     }
 
     private Study findStudyById(Long studyId) {
-        return studyRepository.findById(studyId).orElseThrow(StudyNotFoundException::new);
+        Study study = studyRepository.findById(studyId).orElseThrow(StudyNotFoundException::new);
+        if (study.getDeletedAt() == null) {
+            throw new StudyDeleteException();
+        }
+        return study;
     }
 
     private StudyResponse getStudyResponse(Study study) {

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 스터디게시판입니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 스터디 분야입니다."),
     HAS_NO_PERMISSION_WITH_THIS_STUDY(HttpStatus.UNAUTHORIZED, "해당 스터디 게시글에 대한 권한이 없습니다."),
+    STUDY_DELETED(HttpStatus.NOT_FOUND,"삭제된 스터디 모집글입니다."),
 
     // SSE & NOTIFICATION
     SSE_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 연결에 실패했습니다."),

--- a/src/test/java/com/fasttime/docs/RestDocsSupport.java
+++ b/src/test/java/com/fasttime/docs/RestDocsSupport.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -29,6 +30,7 @@ public abstract class RestDocsSupport {
             .addFilter(new CharacterEncodingFilter("UTF-8", true))
             .setMessageConverters(getLocalDateTimeConverter())
             .build();
+        objectMapper.registerModule(new JavaTimeModule());
     }
 
     public abstract Object initController();

--- a/src/test/java/com/fasttime/domain/study/docs/CategoryControllerTest.java
+++ b/src/test/java/com/fasttime/domain/study/docs/CategoryControllerTest.java
@@ -1,0 +1,60 @@
+package com.fasttime.domain.study.docs;
+
+import com.fasttime.docs.RestDocsSupport;
+import com.fasttime.domain.study.controller.CategoryController;
+import com.fasttime.domain.study.dto.CategoryResponse;
+import com.fasttime.domain.study.service.CategoryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CategoryControllerTest extends RestDocsSupport {
+    private final CategoryService categoryService = mock(CategoryService.class);
+
+    @Override
+    public Object initController() {
+        return new CategoryController(categoryService) ;
+    }
+    @DisplayName("카테고리 목록 조회 API")
+    @Test
+    void getCategories() throws Exception {
+        //given
+        CategoryResponse categoryResponse1 = new CategoryResponse(1L, "백엔드");
+        CategoryResponse categoryResponse2 = new CategoryResponse(2L, "면접 준비");
+
+        List<CategoryResponse> categoryResponses = List.of(categoryResponse1, categoryResponse2);
+
+        when(categoryService.getAllCategories())
+                .thenReturn(categoryResponses);
+
+        //when then
+        mockMvc.perform(get("/api/v2/categories"))
+                .andExpect(status().isOk())
+                .andDo(document("category-get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                                fieldWithPath("message").type(JsonFieldType.NULL).description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.ARRAY).description("카테고리 리스트"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("카테고리 식별자"),
+                                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("카테고리 이름")
+                        )
+                ));
+
+
+    }
+}
+
+

--- a/src/test/java/com/fasttime/domain/study/docs/StudyControllerTest.java
+++ b/src/test/java/com/fasttime/domain/study/docs/StudyControllerTest.java
@@ -1,0 +1,313 @@
+package com.fasttime.domain.study.docs;
+
+import com.fasttime.docs.RestDocsSupport;
+import com.fasttime.domain.study.controller.StudyController;
+import com.fasttime.domain.study.dto.StudyCreateRequest;
+import com.fasttime.domain.study.dto.StudyPageResponse;
+import com.fasttime.domain.study.dto.StudyResponse;
+import com.fasttime.domain.study.dto.StudyUpdateRequest;
+import com.fasttime.domain.study.service.StudyService;
+import com.fasttime.global.util.SecurityUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Attributes;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class StudyControllerTest extends RestDocsSupport {
+    private final StudyService studyService = mock(StudyService.class);
+    private final SecurityUtil securityUtil = mock(SecurityUtil.class);
+
+    @Override
+    public Object initController() {
+        return new StudyController(studyService, securityUtil);
+    }
+
+    @DisplayName("스터디 모집글 작성 API")
+    @Test
+    void creatStudy() throws Exception {
+        //given
+        StudyCreateRequest studyCreateRequest = new StudyCreateRequest(
+                "test 스터티 제목", "test 스터디 본문", "파이썬 자바", 10,
+                LocalDate.now().plusMonths(1),
+                LocalDate.now().plusMonths(1),
+                LocalDate.now().plusMonths(3), "010-0000-0000", List.of(1L, 2L));
+        //when, then
+        when(studyService.createStudy(anyLong(), any(StudyCreateRequest.class)))
+                .thenReturn(StudyResponse.builder()
+                        .id(1L).nickname("부캠러")
+                        .title("Test 스터디 제목")
+                        .content("Test 스터디 본문")
+                        .skill("파이썬 자바")
+                        .recruitmentStart(LocalDate.now())
+                        .recruitmentEnd(LocalDate.now().plusMonths(1))
+                        .progressStart(LocalDate.now().plusMonths(1))
+                        .progressEnd(LocalDate.now().plusMonths(3))
+                        .total(10)
+                        .applicant(0)
+                        .current(0)
+                        .categories(List.of("면접 준비", "알고리즘"))
+                        .contact("010-0000-0000").build());
+
+        mockMvc.perform(post("/api/v2/studies")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(studyCreateRequest)))
+                .andExpect(status().isCreated())
+                .andDo(document("study-create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("skill").type(JsonFieldType.STRING).description("필요 스택"),
+                                fieldWithPath("total").type(JsonFieldType.NUMBER).description("총 인원"),
+                                fieldWithPath("recruitmentEnd").type(JsonFieldType.STRING).description("모집 종료 날짜"),
+                                fieldWithPath("progressStart").type(JsonFieldType.STRING).description("스터디 시작 날짜"),
+                                fieldWithPath("progressEnd").type(JsonFieldType.STRING).description("스터디 종료 날짜"),
+                                fieldWithPath("contact").type(JsonFieldType.STRING).description("연락처"),
+                                fieldWithPath("categoryIds").type(JsonFieldType.ARRAY).description("내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).optional()
+                                        .description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.STRING).description("생성된 스터디 모집글 조회 URL")
+                        )
+                ));
+    }
+
+    @DisplayName("스터디 모집글 수정 API")
+    @Test
+    void updateStudy() throws Exception {
+
+        //given
+        StudyUpdateRequest studyUpdateRequest = new StudyUpdateRequest(
+                "test 스터티 제목", "test 스터디 본문", "파이썬 자바", 10,
+                LocalDate.now().plusMonths(1),
+                LocalDate.now().plusMonths(1),
+                LocalDate.now().plusMonths(3), "010-0000-0000", List.of(1L, 2L));
+
+        //when then
+        when(studyService.updateStudy(anyLong(), anyLong(), any(StudyUpdateRequest.class)))
+                .thenReturn(StudyResponse.builder()
+                        .id(1L).nickname("부캠러")
+                        .title("Test 스터디 제목")
+                        .content("Test 스터디 본문")
+                        .skill("파이썬 자바")
+                        .recruitmentStart(LocalDate.now())
+                        .recruitmentEnd(LocalDate.now().plusMonths(1))
+                        .progressStart(LocalDate.now().plusMonths(1))
+                        .progressEnd(LocalDate.now().plusMonths(3))
+                        .total(10)
+                        .applicant(0)
+                        .current(0)
+                        .categories(List.of("면접 준비", "알고리즘"))
+                        .contact("010-0000-0000").build());
+
+        mockMvc.perform(put("/api/v2/studies/{study_id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(studyUpdateRequest)))
+                .andExpect(status().isOk())
+                .andDo(document("study-update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("study_id").description("삭제할 스터디 모집글 식별자")),
+                        requestFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("skill").type(JsonFieldType.STRING).description("필요 역량"),
+                                fieldWithPath("total").type(JsonFieldType.NUMBER).description("총 인원"),
+                                fieldWithPath("recruitmentEnd").type(JsonFieldType.STRING).description("모집 종료 일시"),
+                                fieldWithPath("progressStart").type(JsonFieldType.STRING).description("스터디 시작 일시"),
+                                fieldWithPath("progressEnd").type(JsonFieldType.STRING).description("스터디 종료 일시"),
+                                fieldWithPath("contact").type(JsonFieldType.STRING).description("연락처"),
+                                fieldWithPath("categoryIds").type(JsonFieldType.ARRAY).description("스터디 카테고리 식별자 리스트")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                                fieldWithPath("message").type(JsonFieldType.NULL).description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.NUMBER).description("수정된 스터디 모집글 ID")
+                        )
+                ));
+    }
+
+    @DisplayName("스터디 모집글 삭제 API")
+    @Test
+    void deleteStudy() throws Exception {
+        //given
+        doNothing().when(studyService).deleteStudy(anyLong(), anyLong());
+
+        //when, then
+        mockMvc.perform(delete("/api/v2/studies/{study_id}", 1L))
+                .andExpect(status().isNoContent())
+                .andDo(document("study-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("study_id").description("삭제할 스터디 모집글 식별자"))
+                ));
+    }
+
+    @DisplayName("스터디 모집글 상세 조회 API ")
+    @Test
+    void searchStudy() throws Exception {
+        //given
+        when(studyService.getStudy(anyLong()))
+                .thenReturn(StudyResponse.builder()
+                        .id(1L).nickname("부캠러")
+                        .title("Test 스터디 제목")
+                        .content("Test 스터디 본문")
+                        .skill("파이썬 자바")
+                        .recruitmentStart(LocalDate.now())
+                        .recruitmentEnd(LocalDate.now().plusMonths(1))
+                        .progressStart(LocalDate.now().plusMonths(1))
+                        .progressEnd(LocalDate.now().plusMonths(3))
+                        .total(10)
+                        .applicant(0)
+                        .current(0)
+                        .categories(List.of("면접 준비", "알고리즘"))
+                        .contact("010-0000-0000").build());
+
+        //when //then
+        mockMvc.perform(get("/api/v2/studies/{study_id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("study-get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("study_id").description("스터디 모집글 식별자")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).optional()
+                                        .description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답데이터"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("스터디 모집글 식별자"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("스터디 모집글 제목"),
+                                fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data.content").type(JsonFieldType.STRING).description("스터디 모집글 본문"),
+                                fieldWithPath("data.skill").type(JsonFieldType.STRING)
+                                        .description("필요 역량"),
+                                fieldWithPath("data.total").type(JsonFieldType.NUMBER).description("총 인원"),
+                                fieldWithPath("data.current").type(JsonFieldType.NUMBER).description("현재 인원"),
+                                fieldWithPath("data.applicant").type(JsonFieldType.NUMBER).description("지원자 수"),
+                                fieldWithPath("data.recruitmentStart").type(JsonFieldType.STRING).description("모집 시작 일시"),
+                                fieldWithPath("data.recruitmentEnd").type(JsonFieldType.STRING).description("모집 종료 일시"),
+                                fieldWithPath("data.progressStart").type(JsonFieldType.STRING).description("스터디 시작 일시"),
+                                fieldWithPath("data.progressEnd").type(JsonFieldType.STRING).description("스터디 종료 일시"),
+                                fieldWithPath("data.contact").type(JsonFieldType.STRING).description("연락처"),
+                                fieldWithPath("data.categories").type(JsonFieldType.ARRAY).description("스터디 카테고리 ")
+                        )));
+    }
+
+    @DisplayName("스터디 모집글 목록 조회 API ")
+    @Test
+    void searchStudies() throws Exception {
+
+        //given
+        StudyResponse studyResponse1 = StudyResponse.builder()
+                .id(1L).nickname("부캠러")
+                .title("Test 스터디 제목1")
+                .content("Test 스터디 본문1")
+                .skill("파이썬 자바")
+                .recruitmentStart(LocalDate.now())
+                .recruitmentEnd(LocalDate.now().plusMonths(1))
+                .progressStart(LocalDate.now().plusMonths(1))
+                .progressEnd(LocalDate.now().plusMonths(3))
+                .total(10)
+                .applicant(0)
+                .current(0)
+                .categories(List.of("면접 준비", "알고리즘"))
+                .contact("010-0000-0000").build();
+        StudyResponse studyResponse2 = StudyResponse.builder()
+                .id(1L).nickname("부캠러")
+                .title("Test 스터디 제목2")
+                .content("Test 스터디 본문2")
+                .skill("파이썬 자바 c++")
+                .recruitmentStart(LocalDate.now())
+                .recruitmentEnd(LocalDate.now().plusMonths(1))
+                .progressStart(LocalDate.now().plusMonths(1))
+                .progressEnd(LocalDate.now().plusMonths(3))
+                .total(5)
+                .applicant(0)
+                .current(0)
+                .categories(List.of("면접 준비", "프로젝트"))
+                .contact("010-0000-0000").build();
+
+        List<StudyResponse> studyResponses = List.of(studyResponse1, studyResponse2);
+
+        when(studyService.searchStudies(any()))
+                .thenReturn(StudyPageResponse.builder()
+                        .studies(studyResponses)
+                        .totalStudies(2)
+                        .totalPages(1)
+                        .isLastPage(true).build());
+
+        //when then
+        mockMvc.perform(get("/api/v2/studies")
+                        .queryParam("page", "0")
+                        .queryParam("pageSize", "10")
+                        .queryParam("orderBy", "latest")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("study-search",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("pageSize").description("조회당 불러올 건 수").optional()
+                                        .attributes(new Attributes.Attribute("defaultValue", "10")),
+                                parameterWithName("page").description("조회 페이지").optional()
+                                        .attributes(new Attributes.Attribute("defaultValue", "0")),
+                                parameterWithName("orderBy").description(
+                                                "정렬 기준 : latest(default), applicant").optional()
+                                        .attributes(new Attributes.Attribute("constraints",
+                                                        "latest : 최신 순 \n applicant : 지원자 수"),
+                                                new Attributes.Attribute("defaultValue", "latest"))
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).optional()
+                                        .description("메시지"),
+                                fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                fieldWithPath("data.isLastPage").type(JsonFieldType.BOOLEAN).description("마지막 페이지인지"),
+                                fieldWithPath("data.totalStudies").type(JsonFieldType.NUMBER)
+                                        .description("스터디 모집글 총 개수"),
+                                fieldWithPath("data.studies").type(JsonFieldType.ARRAY)
+                                        .description("스터디 모집글 리스트"),
+                                fieldWithPath("data.studies[].id").type(JsonFieldType.NUMBER).description("스터디 모집글 식별자"),
+                                fieldWithPath("data.studies[].title").type(JsonFieldType.STRING).description("스터디 모집글 제목"),
+                                fieldWithPath("data.studies[].nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data.studies[].content").type(JsonFieldType.STRING).description("스터디 모집글 본문"),
+                                fieldWithPath("data.studies[].skill").type(JsonFieldType.STRING)
+                                        .description("필요 역량"),
+                                fieldWithPath("data.studies[].total").type(JsonFieldType.NUMBER).description("총 인원"),
+                                fieldWithPath("data.studies[].current").type(JsonFieldType.NUMBER).description("현재 인원"),
+                                fieldWithPath("data.studies[].applicant").type(JsonFieldType.NUMBER).description("지원자 수"),
+                                fieldWithPath("data.studies[].recruitmentStart").type(JsonFieldType.STRING).description("모집 시작 일시"),
+                                fieldWithPath("data.studies[].recruitmentEnd").type(JsonFieldType.STRING).description("모집 종료 일시"),
+                                fieldWithPath("data.studies[].progressStart").type(JsonFieldType.STRING).description("스터디 시작 일시"),
+                                fieldWithPath("data.studies[].progressEnd").type(JsonFieldType.STRING).description("스터디 종료 일시"),
+                                fieldWithPath("data.studies[].contact").type(JsonFieldType.STRING).description("연락처"),
+                                fieldWithPath("data.studies[].categories").type(JsonFieldType.ARRAY).description("스터디 카테고리 ")
+                        )
+                ));
+    }
+}
+


### PR DESCRIPTION
# Pull Request 요약
- 카테고리 조회 로직을 구현하였습니다.
- 기존 발견하지 못했던 오류들을 수정하였습니다.
- 스터디 CRUD, 카테고리 조회 API Controller docs test를 추가하였습니다.

## 변경 사항
- soft delete된 스터디 모집글을 조회하지 않도록 수정하였습니다.
- 카테고리 조회를 위한 로직, API 를 구현하였습니다.
- 스터디 CRUD, 카테고리 조회 API Controller docs test를 추가하였습니다.
-  스터디 CRUD, 카테고리 조회 API docs file를 추가하였습니다.

## 관련 이슈

- #252 

## 개발 유형

- [x] 버그 수정
- [x] 새로운 기능 개발
- [x] 테스트 코드 작성


## 작업 기간

- 작업 시작일: (2024-04-20)
- 작업 종료일: ((2024-04-20)

## 유의사항
- StudyService에 대한 테스트는 추후 구현하겠습니다.
- 평일에 개발이 불가능하여 불가피하게 댓글 CRUD 기능 추가, API test 구현 후 Service test를 구현하겠습니다.

## 참고문헌

- 이 PR을 작성하며 참조한 문헌이나 가이드가 있다면 여기에 링크를 추가하세요.
