### PR TITLE
[Fix] 리뷰 도메인 캐시 임시제거 및 페이지네이션 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -69,10 +69,10 @@ public class ReviewController {
     @GetMapping
     public ResponseEntity<ResponseDTO<Map<String, Object>>> getReviews(
         @RequestParam(required = false) String bootcamp,
-        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "1") int page,
         @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
 
-        Pageable pageable = PageRequest.of(page, 6, Sort.by(sortBy).descending());
+        Pageable pageable = PageRequest.of(page - 1, 6, Sort.by(sortBy).descending());
         Page<ReviewResponseDTO> reviews = reviewService.getSortedReviews(bootcamp, pageable);
         Map<String, Object> responseMap = createPaginationResponse(reviews);
         return ResponseEntity.ok(
@@ -82,9 +82,9 @@ public class ReviewController {
 
     @GetMapping("/summary")
     public ResponseEntity<ResponseDTO<Map<String, Object>>> getBootcampReviewSummaries(
-        @RequestParam(defaultValue = "0") int page) {
+        @RequestParam(defaultValue = "1") int page) {
 
-        Pageable pageable = PageRequest.of(page, 10);
+        Pageable pageable = PageRequest.of(page - 1, 10);
         Page<BootcampReviewSummaryDTO> summaries = reviewService.getBootcampReviewSummaries(
             pageable);
         Map<String, Object> responseMap = createPaginationResponse(summaries);

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -46,7 +46,6 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final BootCampRepository bootCampRepository;
 
-    @CacheEvict(value = {"bootcampReviewSummariesCache", "tagGraphCache", "allReviewsCache"}, allEntries = true)
     public Review createReview(ReviewRequestDTO requestDTO, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
@@ -83,7 +82,6 @@ public class ReviewService {
             .collect(Collectors.toSet());
     }
 
-    @CacheEvict(value = {"bootcampReviewSummariesCache", "tagGraphCache", "allReviewsCache"}, allEntries = true)
     public void deleteReview(Long reviewId, Long memberId) {
         Review review = reviewRepository.findById(reviewId)
             .orElseThrow(ReviewNotFoundException::new);
@@ -98,7 +96,6 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
-    @CacheEvict(value = {"bootcampReviewSummariesCache", "tagGraphCache", "allReviewsCache"}, allEntries = true)
     public Review updateReview(Long reviewId, ReviewRequestDTO requestDTO, Long memberId) {
         Review review = reviewRepository.findById(reviewId)
             .orElseThrow(ReviewNotFoundException::new);
@@ -139,7 +136,6 @@ public class ReviewService {
         return ReviewResponseDTO.of(updatedReview, goodTagContents, badTagContents);
     }
 
-    @Cacheable(value = "allReviewsCache")
     public Page<ReviewResponseDTO> getSortedReviews(String bootcamp, Pageable pageable) {
         Page<Review> reviewPage;
         if (bootcamp != null && !bootcamp.isEmpty()) {
@@ -174,7 +170,6 @@ public class ReviewService {
             .collect(Collectors.toSet());
     }
 
-    @Cacheable(value = "bootcampReviewSummariesCache")
     public Page<BootcampReviewSummaryDTO> getBootcampReviewSummaries(Pageable pageable) {
         List<String> bootcamps = reviewRepository.findAllBootcamps();
         List<BootcampReviewSummaryDTO> summaries = new ArrayList<>();
@@ -190,7 +185,6 @@ public class ReviewService {
         return reviewRepository.findBootcampReviewSummaries(pageable);
     }
 
-    @Cacheable(value = "tagGraphCache", key = "#bootcamp")
     public TagSummaryDTO getBootcampTagData(String bootcamp) {
 
         boolean exists = bootCampRepository.existsByName(bootcamp);

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -182,7 +182,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
 
         mockMvc.perform(get("/api/v2/reviews")
                 .queryParam("bootcamp", "")
-                .queryParam("page", "0")
+                .queryParam("page", "")
                 .queryParam("size", "6")
                 .queryParam("sortBy", "rating"))
             .andExpect(status().isOk())
@@ -231,7 +231,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
 
         mockMvc.perform(get("/api/v2/reviews")
                 .queryParam("bootcamp", "패스트캠퍼스X야놀자 부트캠프")
-                .queryParam("page", "0")
+                .queryParam("page", "1")
                 .queryParam("size", "6")
                 .queryParam("sortBy", "rating"))
             .andExpect(status().isOk())
@@ -272,7 +272,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
             new BootcampReviewSummaryDTO("다른 부트캠프", 4.5, 2l)
         );
 
-        int page = 0;
+        int page = 1;
         int size = 10;
         Pageable pageable = PageRequest.of(page, size);
 

--- a/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
+++ b/src/test/java/com/fasttime/domain/review/docs/ReviewControllerDocsTest.java
@@ -182,7 +182,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
 
         mockMvc.perform(get("/api/v2/reviews")
                 .queryParam("bootcamp", "")
-                .queryParam("page", "")
+                .queryParam("page", "1")
                 .queryParam("size", "6")
                 .queryParam("sortBy", "rating"))
             .andExpect(status().isOk())
@@ -274,7 +274,7 @@ class ReviewControllerDocsTest extends RestDocsSupport {
 
         int page = 1;
         int size = 10;
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
 
         Page<BootcampReviewSummaryDTO> pagedSummaries = new PageImpl<>(summaries, pageable, summaries.size());
 


### PR DESCRIPTION
# Pull Request 요약

- [Fix] 리뷰 도메인 캐시 임시제거 및 페이지네이션 수정

## 변경 사항

- 리뷰 조회 page 1로 수정(기존엔 0부터 시작하였음)
- 페이지네이션 관련 테스트 코드 수정

## 관련 이슈

- 이 PR은 어떤 이슈로부터 만들어졌나요? (예: `#123`)

## 개발 유형

- [x] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-04-22)
- 작업 종료일: (2024-04-22)

## 유의사항

- 빠른 프론트 개발을 위해 리뷰 조회에 붙어있던 캐시를 임의로 제거하였습니다. 후에 문제 원인 파악하여 다시 캐시를 붙일 예정입니다.

