### PR TITLE
[Feature] 자기소개서 좋아요 & 조회수 기능 추가

### DIFF
--- a/src/main/java/com/fasttime/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/fasttime/domain/resume/controller/ResumeController.java
@@ -75,8 +75,9 @@ public class ResumeController {
             @RequestParam(name = "orderBy", defaultValue = "date") String orderBy) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDTO.res(HttpStatus.OK,
-                resumeService.search(
-                        new ResumesSearchRequest(ResumeOrderBy.of(orderBy), page, pageSize))));
+                        resumeService.search(
+                                new ResumesSearchRequest(ResumeOrderBy.of(orderBy), page,
+                                        pageSize))));
     }
 
 }

--- a/src/main/java/com/fasttime/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/fasttime/domain/resume/controller/ResumeController.java
@@ -10,6 +10,7 @@ import com.fasttime.domain.resume.repository.ResumeOrderBy;
 import com.fasttime.domain.resume.service.ResumeService;
 import com.fasttime.global.util.ResponseDTO;
 import com.fasttime.global.util.SecurityUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -60,9 +61,11 @@ public class ResumeController {
     }
 
     @GetMapping("/{resumeId}")
-    public ResponseEntity<ResponseDTO<ResumeResponseDto>> getResume(@PathVariable Long resumeId) {
+    public ResponseEntity<ResponseDTO<ResumeResponseDto>> getResume(@PathVariable Long resumeId,
+            HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ResponseDTO.res(HttpStatus.OK, resumeService.getResume(resumeId)));
+                .body(ResponseDTO.res(HttpStatus.OK,
+                        resumeService.getResume(resumeId, request.getRemoteAddr())));
     }
 
     @GetMapping

--- a/src/main/java/com/fasttime/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/fasttime/domain/resume/controller/ResumeController.java
@@ -1,5 +1,6 @@
 package com.fasttime.domain.resume.controller;
 
+import com.fasttime.domain.resume.dto.LikeResumeRequest;
 import com.fasttime.domain.resume.dto.ResumeDeleteServiceRequest;
 import com.fasttime.domain.resume.dto.ResumeRequestDto;
 import com.fasttime.domain.resume.dto.ResumeResponseDto;
@@ -78,6 +79,22 @@ public class ResumeController {
                         resumeService.search(
                                 new ResumesSearchRequest(ResumeOrderBy.of(orderBy), page,
                                         pageSize))));
+    }
+
+    @PostMapping("/{resumeId}/likes")
+    public ResponseEntity<ResponseDTO<Object>> likeResume(@PathVariable Long resumeId) {
+        resumeService.likeResume(
+                new LikeResumeRequest(resumeId, securityUtil.getCurrentMemberId()));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDTO.res(HttpStatus.OK, "정상적으로 처리되었습니다."));
+    }
+
+    @DeleteMapping("/{resumeId}/likes")
+    public ResponseEntity<ResponseDTO<Object>> cancelLike(@PathVariable Long resumeId) {
+        resumeService.cancelLike(
+                new LikeResumeRequest(resumeId, securityUtil.getCurrentMemberId()));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDTO.res(HttpStatus.OK, "정상적으로 처리되었습니다."));
     }
 
 }

--- a/src/main/java/com/fasttime/domain/resume/dto/LikeResumeRequest.java
+++ b/src/main/java/com/fasttime/domain/resume/dto/LikeResumeRequest.java
@@ -1,0 +1,8 @@
+package com.fasttime.domain.resume.dto;
+
+public record LikeResumeRequest(
+        Long resumeId,
+        Long memberId
+) {
+
+}

--- a/src/main/java/com/fasttime/domain/resume/entity/Like.java
+++ b/src/main/java/com/fasttime/domain/resume/entity/Like.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class Like extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,8 +31,10 @@ public class Like extends BaseTimeEntity {
     private Resume resume;
 
     @Builder
-    public Like(Member member, Resume resume){
+    public Like(Member member, Resume resume) {
         this.member = member;
         this.resume = resume;
     }
+
+
 }

--- a/src/main/java/com/fasttime/domain/resume/entity/Like.java
+++ b/src/main/java/com/fasttime/domain/resume/entity/Like.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
+@Entity(name = "resume_like")
 @Getter
 @NoArgsConstructor
 public class Like extends BaseTimeEntity {

--- a/src/main/java/com/fasttime/domain/resume/entity/Like.java
+++ b/src/main/java/com/fasttime/domain/resume/entity/Like.java
@@ -1,0 +1,37 @@
+package com.fasttime.domain.resume.entity;
+
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Like extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Builder
+    public Like(Member member, Resume resume){
+        this.member = member;
+        this.resume = resume;
+    }
+}

--- a/src/main/java/com/fasttime/domain/resume/entity/Resume.java
+++ b/src/main/java/com/fasttime/domain/resume/entity/Resume.java
@@ -63,6 +63,13 @@ public class Resume extends BaseTimeEntity {
         this.likeCount += 1;
     }
 
+    public void cancelLike() {
+        if (this.likeCount > 0) {
+            this.likeCount -= 1;
+        }
+
+    }
+
     public void view() {
         this.viewCount += 1;
     }

--- a/src/main/java/com/fasttime/domain/resume/exception/AlreadyExistsResumeLikeException.java
+++ b/src/main/java/com/fasttime/domain/resume/exception/AlreadyExistsResumeLikeException.java
@@ -1,0 +1,17 @@
+package com.fasttime.domain.resume.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class AlreadyExistsResumeLikeException extends ApplicationException {
+    private final static ErrorCode errorCode = ErrorCode.ALREADY_LIKE_THIS_RESUME;
+
+    public AlreadyExistsResumeLikeException() {
+        super(errorCode);
+    }
+
+    public AlreadyExistsResumeLikeException(ErrorCode errorCode,
+            String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/fasttime/domain/resume/exception/UnauthorizedAccessLikeException.java
+++ b/src/main/java/com/fasttime/domain/resume/exception/UnauthorizedAccessLikeException.java
@@ -1,0 +1,17 @@
+package com.fasttime.domain.resume.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import com.fasttime.global.exception.ErrorCode;
+
+public class UnauthorizedAccessLikeException extends ApplicationException {
+
+    private final static ErrorCode errorCode = ErrorCode.HAS_NO_PERMISSION_WITH_THIS_LIKE;
+
+    public UnauthorizedAccessLikeException() {
+        super(errorCode);
+    }
+
+    public UnauthorizedAccessLikeException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/fasttime/domain/resume/repository/LikeRepository.java
+++ b/src/main/java/com/fasttime/domain/resume/repository/LikeRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     boolean existsByMemberAndResume(Member member, Resume resume);
+
+    void deleteByMemberAndResume(Member member, Resume resume);
 }

--- a/src/main/java/com/fasttime/domain/resume/repository/LikeRepository.java
+++ b/src/main/java/com/fasttime/domain/resume/repository/LikeRepository.java
@@ -1,0 +1,11 @@
+package com.fasttime.domain.resume.repository;
+
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.resume.entity.Like;
+import com.fasttime.domain.resume.entity.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    boolean existsByMemberAndResume(Member member, Resume resume);
+}

--- a/src/main/java/com/fasttime/domain/resume/repository/ResumeCustomRepository.java
+++ b/src/main/java/com/fasttime/domain/resume/repository/ResumeCustomRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 public interface ResumeCustomRepository {
 
     List<Resume> search(ResumesSearchRequest searchCondition);
+    void addViewCountFromRedis(Long resumeId, Long viewCount);
 
+    Long getLikeCount(Long resumeId);
 }

--- a/src/main/java/com/fasttime/domain/resume/repository/ResumeCustomRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/resume/repository/ResumeCustomRepositoryImpl.java
@@ -41,6 +41,12 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
                 .execute();
     }
 
+    @Override
+    public Long getLikeCount(Long resumeId) {
+        return Long.valueOf(
+                jpaQueryFactory.select(resume.likeCount).from(resume).where(resume.id.eq(resumeId)).fetchOne());
+    }
+
     private BooleanBuilder createResumeSearchCondition(ResumesSearchRequest searchCondition) {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(resume.deletedAt.isNull());

--- a/src/main/java/com/fasttime/domain/resume/repository/ResumeCustomRepositoryImpl.java
+++ b/src/main/java/com/fasttime/domain/resume/repository/ResumeCustomRepositoryImpl.java
@@ -33,6 +33,14 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
                 .fetch();
     }
 
+    @Override
+    public void addViewCountFromRedis(Long resumeId, Long viewCount) {
+        jpaQueryFactory.update(resume)
+                .where(resume.id.eq(resumeId))
+                .set(resume.viewCount, resume.viewCount.add(viewCount))
+                .execute();
+    }
+
     private BooleanBuilder createResumeSearchCondition(ResumesSearchRequest searchCondition) {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(resume.deletedAt.isNull());

--- a/src/main/java/com/fasttime/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/fasttime/domain/resume/service/ResumeService.java
@@ -120,9 +120,6 @@ public class ResumeService {
     private void addViewCntToRedis(Long resumeId, String remoteAddr) {
         String key = "resumeId: " + resumeId;
         SetOperations<String, String> setOperations = redisTemplate.opsForSet();
-        if (Boolean.TRUE.equals(setOperations.isMember(key, remoteAddr))) {
-            return;
-        }
         setOperations.add(key, remoteAddr);
     }
 

--- a/src/main/java/com/fasttime/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/fasttime/domain/resume/service/ResumeService.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -97,7 +96,7 @@ public class ResumeService {
     public void likeResume(LikeResumeRequest likeResumeRequest) {
         Member member = memberService.getMember(likeResumeRequest.memberId());
         Resume resume = resumeRepository.findById(likeResumeRequest.resumeId())
-                .orElseThrow(() -> new ResumeNotFoundException(likeResumeRequest.resumeId()));
+                .orElseThrow(ResumeNotFoundException::new);
         if (likeRepository.existsByMemberAndResume(member, resume)) {
             throw new AlreadyExistsResumeLikeException();
         }
@@ -128,9 +127,8 @@ public class ResumeService {
     }
 
 
-    private void updateViewCntToDB() {
+    public void updateViewCntToDB() {
         SetOperations<String, String> setOperations = redisTemplate.opsForSet();
-        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         Set<String> redisKeys = redisTemplate.keys("resumeId*");
         for (String keyName : redisKeys) {
             Long resumeId = extractResumeId(keyName);

--- a/src/main/java/com/fasttime/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/fasttime/domain/resume/service/ResumeService.java
@@ -106,10 +106,10 @@ public class ResumeService {
         likeRepository.save(Like.builder().resume(resume).member(member).build());
     }
 
-    public void cancelLike(Long resumeId, Long memberId) {
-        Member member = memberService.getMember(memberId);
-        Resume resume = resumeRepository.findById(resumeId)
-                .orElseThrow(() -> new ResumeNotFoundException(resumeId));
+    public void cancelLike(LikeResumeRequest likeResumeRequest) {
+        Member member = memberService.getMember(likeResumeRequest.memberId());
+        Resume resume = resumeRepository.findById(likeResumeRequest.resumeId())
+                .orElseThrow(ResumeNotFoundException::new);
 
         if (!likeRepository.existsByMemberAndResume(member, resume)) {
             throw new UnauthorizedAccessLikeException();

--- a/src/main/java/com/fasttime/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/fasttime/global/batch/scheduler/BatchScheduler.java
@@ -49,7 +49,7 @@ public class BatchScheduler {
         jobLauncher.run(deleteCertificationsJob, new JobParameters());
     }
 
-    @Scheduled(cron = "*/10 * * * *")
+    @Scheduled(cron = "0 */10 * * * *")
     public void runUpdateResumeViewCountToDbJob() throws JobExecutionException {
         jobLauncher.run(updateResumeViewCountToDbJob, new JobParameters());
     }

--- a/src/main/java/com/fasttime/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/fasttime/global/batch/scheduler/BatchScheduler.java
@@ -4,9 +4,11 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
+@Configuration
 @EnableScheduling
 public class BatchScheduler {
 
@@ -15,14 +17,16 @@ public class BatchScheduler {
     private final Job updateReferenceJob;
     private final Job updateReferenceStatusJob;
     private final Job deleteCertificationsJob;
+    private final Job updateResumeViewCountToDbJob;
 
     public BatchScheduler(JobLauncher jobLauncher, Job deleteOldReviewsJob, Job updateReferenceJob,
-        Job deleteCertificationsJob) {
+            Job deleteCertificationsJob, Job updateResumeViewCountToDbJob) {
         this.jobLauncher = jobLauncher;
         this.deleteOldReviewsJob = deleteOldReviewsJob;
         this.updateReferenceJob = updateReferenceJob;
         this.updateReferenceStatusJob = updateReferenceJob;
         this.deleteCertificationsJob = deleteCertificationsJob;
+        this.updateResumeViewCountToDbJob = updateResumeViewCountToDbJob;
     }
 
     @Scheduled(cron = "0 0 3 * * *")
@@ -43,5 +47,10 @@ public class BatchScheduler {
     @Scheduled(cron = "0 0 3 * * *")
     public void runDeleteCertificationsJob() throws JobExecutionException {
         jobLauncher.run(deleteCertificationsJob, new JobParameters());
+    }
+
+    @Scheduled(cron = "*/10 * * * *")
+    public void runUpdateResumeViewCountToDbJob() throws JobExecutionException {
+        jobLauncher.run(updateResumeViewCountToDbJob, new JobParameters());
     }
 }

--- a/src/main/java/com/fasttime/global/batch/tasklet/UpdateResumeViewCountTasklet.java
+++ b/src/main/java/com/fasttime/global/batch/tasklet/UpdateResumeViewCountTasklet.java
@@ -1,0 +1,27 @@
+package com.fasttime.global.batch.tasklet;
+
+import com.fasttime.domain.resume.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateResumeViewCountTasklet implements Tasklet {
+
+    private final ResumeService resumeService;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
+            throws Exception {
+        log.info("Redis에 있는 자기소개서 ViewCount DB로 Update");
+        resumeService.updateViewCntToDB();
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/fasttime/global/config/BatchConfig.java
+++ b/src/main/java/com/fasttime/global/config/BatchConfig.java
@@ -10,6 +10,7 @@ import com.fasttime.global.batch.tasklet.UpdateDoneActivityTasklet;
 import com.fasttime.global.batch.tasklet.UpdateDoneCompetitionTasklet;
 import com.fasttime.global.batch.tasklet.UpdateNewActivityTasklet;
 import com.fasttime.global.batch.tasklet.UpdateNewCompetitionTasklet;
+import com.fasttime.global.batch.tasklet.UpdateResumeViewCountTasklet;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -27,18 +28,18 @@ public class BatchConfig {
 
     @Bean
     public Job deleteOldReviewsJob(JobRepository jobRepository,
-        @Qualifier("deleteOldReviewsStep") Step deleteOldReviewsStep) {
+            @Qualifier("deleteOldReviewsStep") Step deleteOldReviewsStep) {
         return new JobBuilder("deleteOldReviewsJob", jobRepository)
-            .start(deleteOldReviewsStep)
-            .build();
+                .start(deleteOldReviewsStep)
+                .build();
     }
 
     @Bean
     public Step deleteOldReviewsStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, DeleteOldReviewsTasklet tasklet) {
+            PlatformTransactionManager transactionManager, DeleteOldReviewsTasklet tasklet) {
         return new StepBuilder("deleteOldReviewsStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
@@ -48,95 +49,112 @@ public class BatchConfig {
 
     @Bean
     public Job updateReferenceStatusJob(JobRepository jobRepository,
-        @Qualifier("updateActivityStatusStep") Step updateActivityStatusStep,
-        @Qualifier("updateCompetitionStatusStep") Step updateCompetitionStatusStep) {
+            @Qualifier("updateActivityStatusStep") Step updateActivityStatusStep,
+            @Qualifier("updateCompetitionStatusStep") Step updateCompetitionStatusStep) {
         return new JobBuilder("updateReferenceStatusJob", jobRepository)
-            .start(updateActivityStatusStep)
-            .next(updateCompetitionStatusStep)
-            .build();
+                .start(updateActivityStatusStep)
+                .next(updateCompetitionStatusStep)
+                .build();
     }
 
     @Bean
     public Job updateReferenceJob(JobRepository jobRepository,
-        @Qualifier("updateNewActivityStep") Step updateNewActivityStep,
-        @Qualifier("updateNewCompetitionStep") Step updateNewCompetitionStep,
-        @Qualifier("updateDoneActivityStep") Step updateDoneActivityStep,
-        @Qualifier("updateDoneCompetitionStep") Step updateDoneCompetitionStep) {
+            @Qualifier("updateNewActivityStep") Step updateNewActivityStep,
+            @Qualifier("updateNewCompetitionStep") Step updateNewCompetitionStep,
+            @Qualifier("updateDoneActivityStep") Step updateDoneActivityStep,
+            @Qualifier("updateDoneCompetitionStep") Step updateDoneCompetitionStep) {
 
         return new JobBuilder("updateReferenceJob", jobRepository)
-            .start(updateNewActivityStep)
-            .next(updateNewCompetitionStep)
-            .next(updateDoneActivityStep)
-            .next(updateDoneCompetitionStep)
-            .build();
+                .start(updateNewActivityStep)
+                .next(updateNewCompetitionStep)
+                .next(updateDoneActivityStep)
+                .next(updateDoneCompetitionStep)
+                .build();
     }
 
     @Bean
     public Step updateActivityStatusStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateActivityStatusTasklet tasklet) {
+            PlatformTransactionManager transactionManager, UpdateActivityStatusTasklet tasklet) {
         return new StepBuilder("updateActivityStatusStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
     public Step updateCompetitionStatusStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateCompetitionStatusTasklet tasklet) {
+            PlatformTransactionManager transactionManager, UpdateCompetitionStatusTasklet tasklet) {
         return new StepBuilder("updateCompetitionStatusStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
     public Step updateNewActivityStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateNewActivityTasklet tasklet) {
+            PlatformTransactionManager transactionManager, UpdateNewActivityTasklet tasklet) {
         return new StepBuilder("updateNewActivityStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
     public Step updateNewCompetitionStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateNewCompetitionTasklet tasklet) {
+            PlatformTransactionManager transactionManager, UpdateNewCompetitionTasklet tasklet) {
         return new StepBuilder("updateNewCompetitionStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
     public Step updateDoneActivityStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateDoneActivityTasklet tasklet) {
+            PlatformTransactionManager transactionManager, UpdateDoneActivityTasklet tasklet) {
         return new StepBuilder("updateDoneActivityStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
     public Step updateDoneCompetitionStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, UpdateDoneCompetitionTasklet tasklet) {
+            PlatformTransactionManager transactionManager, UpdateDoneCompetitionTasklet tasklet) {
         return new StepBuilder("updateDoneCompetitionStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
     }
 
     @Bean
     public DeleteCertificationsTasklet deleteCertificationsTasklet(
-        CertificationRepository certificationRepository) {
+            CertificationRepository certificationRepository) {
         return new DeleteCertificationsTasklet(certificationRepository);
     }
 
     @Bean
     public Job deleteCertificationsJob(JobRepository jobRepository, Step deleteCertificationsStep) {
         return new JobBuilder("deleteCertificationsJob", jobRepository)
-            .start(deleteCertificationsStep)
-            .build();
+                .start(deleteCertificationsStep)
+                .build();
     }
 
     @Bean
     public Step deleteCertificationsStep(JobRepository jobRepository,
-        PlatformTransactionManager transactionManager, DeleteCertificationsTasklet tasklet) {
+            PlatformTransactionManager transactionManager, DeleteCertificationsTasklet tasklet) {
         return new StepBuilder("deleteCertificationsStep", jobRepository)
-            .tasklet(tasklet, transactionManager)
-            .build();
+                .tasklet(tasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Job updateResumeViewCountToDbJob(JobRepository jobRepository,
+            @Qualifier("updateResumeViewCountStep") Step updateResumeViewCountStep) {
+        return new JobBuilder("updateResumeViewCountToDbJob", jobRepository)
+                .start(updateResumeViewCountStep)
+                .build();
+    }
+
+    @Bean
+    public Step updateResumeViewCountStep(JobRepository jobRepository,
+            UpdateResumeViewCountTasklet tasklet, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("updateResumeViewCountStep", jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .allowStartIfComplete(Boolean.TRUE)
+                .build();
     }
 }

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 자기소개서입니다."),
     RESUME_IS_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제한 자기소개서입니다."),
     HAS_NO_PERMISSION_WITH_THIS_RESUME(HttpStatus.UNAUTHORIZED, "해당 자기소개서에 대한 권한이 없습니다."),
+    ALREADY_LIKE_THIS_RESUME(HttpStatus.BAD_REQUEST, "이미 좋아요한 자기소개서입니다."),
 
     // REFERENCE
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 대외활동입니다."),

--- a/src/main/java/com/fasttime/global/exception/ErrorCode.java
+++ b/src/main/java/com/fasttime/global/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     RESUME_IS_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제한 자기소개서입니다."),
     HAS_NO_PERMISSION_WITH_THIS_RESUME(HttpStatus.UNAUTHORIZED, "해당 자기소개서에 대한 권한이 없습니다."),
     ALREADY_LIKE_THIS_RESUME(HttpStatus.BAD_REQUEST, "이미 좋아요한 자기소개서입니다."),
+    HAS_NO_PERMISSION_WITH_THIS_LIKE(HttpStatus.UNAUTHORIZED, "좋아요 삭제 권한이 없습니다."),
 
     // REFERENCE
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 대외활동입니다."),

--- a/src/main/resources/db/migration/V25_Add_Resume_Table.sql
+++ b/src/main/resources/db/migration/V25_Add_Resume_Table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE resume_like
+(
+    id         BIGINT AUTO_INCREMENT NOT NULL,
+    created_at datetime NULL,
+    updated_at datetime NULL,
+    deleted_at datetime NULL,
+    member_id  BIGINT NULL,
+    resume_id  BIGINT NULL,
+    CONSTRAINT pk_like PRIMARY KEY (id)
+);
+
+ALTER TABLE resume_like
+    ADD CONSTRAINT FK_LIKE_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (id);
+ALTER TABLE resume_like
+    ADD CONSTRAINT FK_LIKE_ON_RESUME FOREIGN KEY (resume_id) REFERENCES resume (id);

--- a/src/test/java/com/fasttime/domain/resume/unit/service/ResumeServiceTest.java
+++ b/src/test/java/com/fasttime/domain/resume/unit/service/ResumeServiceTest.java
@@ -173,13 +173,14 @@ class ResumeServiceTest {
         @Test
         void _willSuccess() {
             // given
+            String testRemoteAddress = "test remote address";
             Member member = Member.builder().id(1L).nickname("testName").build();
             Resume resumeInDb = createMockResume(member);
 
             given(resumeRepository.findById(anyLong())).willReturn(Optional.of(resumeInDb));
 
             // when
-            ResumeResponseDto response = resumeService.getResume(1L);
+            ResumeResponseDto response = resumeService.getResume(1L, testRemoteAddress);
 
             // then
             assertThat(response).extracting("id", "title", "content", "writer", "likeCount",
@@ -194,7 +195,7 @@ class ResumeServiceTest {
             given(resumeRepository.findById(anyLong())).willReturn(Optional.empty());
 
             // when
-            assertThatThrownBy(() -> resumeService.getResume(5L)).isInstanceOf(
+            assertThatThrownBy(() -> resumeService.getResume(5L, "test remote address")).isInstanceOf(
                     ResumeNotFoundException.class);
         }
     }
@@ -267,8 +268,7 @@ class ResumeServiceTest {
             given(memberService.getMember(memberId)).willReturn(member);
             given(resumeRepository.findById(anyLong())).willReturn(Optional.of(resume));
             given(likeRepository.existsByMemberAndResume(member, resume)).willReturn(true);
-
-            resumeService.cancelLike(MOCK_RESUME_ID, memberId);
+            resumeService.cancelLike(new LikeResumeRequest(MOCK_RESUME_ID, memberId));
 
             // then
             assertThat(resume.getLikeCount()).isEqualTo(0);
@@ -297,7 +297,7 @@ class ResumeServiceTest {
 
             // then
             assertThatThrownBy(
-                    () -> resumeService.cancelLike(MOCK_RESUME_ID, 321L)).isInstanceOf(
+                    () -> resumeService.cancelLike(new LikeResumeRequest(MOCK_RESUME_ID, 321L))).isInstanceOf(
                     UnauthorizedAccessLikeException.class);
         }
 
@@ -322,7 +322,7 @@ class ResumeServiceTest {
             given(resumeRepository.findById(anyLong())).willReturn(Optional.of(resume));
             given(likeRepository.existsByMemberAndResume(member, resume)).willReturn(true);
 
-            resumeService.cancelLike(MOCK_RESUME_ID, memberId);
+            resumeService.cancelLike(new LikeResumeRequest(MOCK_RESUME_ID, memberId));
 
             // then
             assertThat(resume.getLikeCount()).isEqualTo(0);

--- a/src/test/java/com/fasttime/domain/resume/unit/service/ResumeServiceTest.java
+++ b/src/test/java/com/fasttime/domain/resume/unit/service/ResumeServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @ExtendWith(MockitoExtension.class)
 @Slf4j
@@ -48,6 +50,8 @@ class ResumeServiceTest {
     private ResumeRepository resumeRepository;
     @Mock
     private LikeRepository likeRepository;
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
 
     @DisplayName("createResume()는")
     @Nested
@@ -173,12 +177,12 @@ class ResumeServiceTest {
         @Test
         void _willSuccess() {
             // given
-            String testRemoteAddress = "test remote address";
+
+            String testRemoteAddress = "0:0:0:0";
             Member member = Member.builder().id(1L).nickname("testName").build();
             Resume resumeInDb = createMockResume(member);
-
             given(resumeRepository.findById(anyLong())).willReturn(Optional.of(resumeInDb));
-
+            given(redisTemplate.opsForSet()).willReturn(mock());
             // when
             ResumeResponseDto response = resumeService.getResume(1L, testRemoteAddress);
 
@@ -195,7 +199,8 @@ class ResumeServiceTest {
             given(resumeRepository.findById(anyLong())).willReturn(Optional.empty());
 
             // when
-            assertThatThrownBy(() -> resumeService.getResume(5L, "test remote address")).isInstanceOf(
+            assertThatThrownBy(
+                    () -> resumeService.getResume(5L, "test remote address")).isInstanceOf(
                     ResumeNotFoundException.class);
         }
     }
@@ -297,7 +302,8 @@ class ResumeServiceTest {
 
             // then
             assertThatThrownBy(
-                    () -> resumeService.cancelLike(new LikeResumeRequest(MOCK_RESUME_ID, 321L))).isInstanceOf(
+                    () -> resumeService.cancelLike(
+                            new LikeResumeRequest(MOCK_RESUME_ID, 321L))).isInstanceOf(
                     UnauthorizedAccessLikeException.class);
         }
 


### PR DESCRIPTION
# Pull Request 요약

- 자기소개서 좋아요, 좋아요 취소 기능
- 자기소개서 조회수 측정 기능

## 변경 사항

- 자기소개서 좋아요 기능
  - 자기소개서에 좋아요를 할 수 있는 기능
  - 유저 `token`을 헤더에 넣어서 사용
  - 유저 중복 요청 불가능
- 자기소개서 좋아요 취소 기능
  - 좋아요를 한 자기소개서에 좋아요 취소 기능
  - 유저 token을 헤더에 넣어서 사용
  - 좋아요를 하지 않은 경우 예외처리
- 조회수 기능 추가
  - 자기소개서를 조회할 때, `redis`에 `ip`를 저장해 중복 조회수 카운팅 방지
  - 10분마다 스케줄러를 통해 자기소개서 조회수 업데이트


## 관련 이슈

#206 
#207 

## 개발 유형

- [ ] 버그 수정
- [x] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- 기타 (아래에 설명 추가)

## 작업 기간

- 작업 시작일: (2024-04-18)
- 작업 종료일: (2024-04-26)

## 유의사항

- 10분마다 스케줄러가 update 연산을 진행

## 참고문헌

- 이 PR을 작성하며 참조한 문헌이나 가이드가 있다면 여기에 링크를 추가하세요.
