### PR TITLE
[Refactor] 리뷰도메인 캐시 재설정

### DIFF
--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -46,6 +46,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final BootCampRepository bootCampRepository;
 
+    @CacheEvict(value = {"bootcampReviewSummariesCache", "tagGraphCache", "allReviewsCache"}, allEntries = true)
     public Review createReview(ReviewRequestDTO requestDTO, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
@@ -82,6 +83,7 @@ public class ReviewService {
             .collect(Collectors.toSet());
     }
 
+    @CacheEvict(value = {"bootcampReviewSummariesCache", "tagGraphCache", "allReviewsCache"}, allEntries = true)
     public void deleteReview(Long reviewId, Long memberId) {
         Review review = reviewRepository.findById(reviewId)
             .orElseThrow(ReviewNotFoundException::new);
@@ -96,6 +98,7 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
+    @CacheEvict(value = {"bootcampReviewSummariesCache", "tagGraphCache", "allReviewsCache"}, allEntries = true)
     public Review updateReview(Long reviewId, ReviewRequestDTO requestDTO, Long memberId) {
         Review review = reviewRepository.findById(reviewId)
             .orElseThrow(ReviewNotFoundException::new);
@@ -136,6 +139,7 @@ public class ReviewService {
         return ReviewResponseDTO.of(updatedReview, goodTagContents, badTagContents);
     }
 
+    @Cacheable(value = "allReviewsCache")
     public Page<ReviewResponseDTO> getSortedReviews(String bootcamp, Pageable pageable) {
         Page<Review> reviewPage;
         if (bootcamp != null && !bootcamp.isEmpty()) {
@@ -170,6 +174,7 @@ public class ReviewService {
             .collect(Collectors.toSet());
     }
 
+    @Cacheable(value = "bootcampReviewSummariesCache")
     public Page<BootcampReviewSummaryDTO> getBootcampReviewSummaries(Pageable pageable) {
         List<String> bootcamps = reviewRepository.findAllBootcamps();
         List<BootcampReviewSummaryDTO> summaries = new ArrayList<>();
@@ -185,6 +190,7 @@ public class ReviewService {
         return reviewRepository.findBootcampReviewSummaries(pageable);
     }
 
+    @Cacheable(value = "tagGraphCache", key = "#bootcamp")
     public TagSummaryDTO getBootcampTagData(String bootcamp) {
 
         boolean exists = bootCampRepository.existsByName(bootcamp);


### PR DESCRIPTION
# ⭐️ [Refactor] 리뷰도메인 캐시 재설정

- dev서버의 redis에 문제가 생겨 임시로 제거한 캐시를 다시 추가하였습니다.


## 관련 이슈

- #255 

## 개발 유형

- [x] 버그 수정
- [ ] 새로운 기능 개발
- [x] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## 작업 기간

- 작업 시작일: (2024-05-09)
- 작업 종료일: (2024-05-09)


