### PR TITLE
[Fix] Review 조회 페이지네이션 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/fasttime/domain/review/controller/ReviewController.java
@@ -2,17 +2,15 @@ package com.fasttime.domain.review.controller;
 
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
 import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
+import com.fasttime.domain.review.dto.response.PageDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.dto.response.TagSummaryDTO;
 import com.fasttime.domain.review.service.ReviewService;
 import com.fasttime.global.util.ResponseDTO;
 import com.fasttime.global.util.SecurityUtil;
 import jakarta.validation.Valid;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -68,17 +66,15 @@ public class ReviewController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDTO<Map<String, Object>>> getReviews(
+    public ResponseEntity<ResponseDTO<PageDTO<ReviewResponseDTO>>> getReviews(
         @RequestParam(required = false) String bootcamp,
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(required = false, defaultValue = "createdAt") String sortBy) {
 
         Pageable pageable = PageRequest.of(page - 1, 6, Sort.by(sortBy).descending());
-        Page<ReviewResponseDTO> reviews = reviewService.getSortedReviews(bootcamp, pageable);
-        Map<String, Object> responseMap = createPaginationResponse(reviews);
+        PageDTO<ReviewResponseDTO> responseDTO = reviewService.getSortedReviews(bootcamp, pageable);
         return ResponseEntity.ok(
-            ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, responseMap));
-
+            ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, responseDTO));
     }
 
     @GetMapping("/summary")
@@ -93,15 +89,5 @@ public class ReviewController {
         @RequestParam String bootcamp) {
         TagSummaryDTO tagData = reviewService.getBootcampTagData(bootcamp);
         return ResponseEntity.ok(ResponseDTO.res(HttpStatus.OK, REVIEW_SUCCESS_MESSAGE, tagData));
-    }
-
-    private Map<String, Object> createPaginationResponse(Page<?> page) {
-        Map<String, Object> responseMap = new LinkedHashMap<>();
-        responseMap.put("currentPage", page.getNumber() + 1);
-        responseMap.put("totalPages", page.getTotalPages());
-        responseMap.put("currentElements", page.getNumberOfElements());
-        responseMap.put("totalElements", page.getTotalElements());
-        responseMap.put("reviews", page.getContent());
-        return responseMap;
     }
 }

--- a/src/main/java/com/fasttime/domain/review/dto/response/PageDTO.java
+++ b/src/main/java/com/fasttime/domain/review/dto/response/PageDTO.java
@@ -1,0 +1,36 @@
+package com.fasttime.domain.review.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@NoArgsConstructor
+@Getter
+public class PageDTO<T> {
+
+    private int currentPage;
+    private int totalPages;
+    private int currentElements;
+    private long totalElements;
+    private List<T> reviews;
+
+    public PageDTO(int currentPage, int totalPages, int currentElements, long totalElements,
+        List<T> reviews) {
+        this.currentPage = currentPage;
+        this.totalPages = totalPages;
+        this.currentElements = currentElements;
+        this.totalElements = totalElements;
+        this.reviews = reviews;
+    }
+
+    public static <T> PageDTO<T> fromPage(Page<T> page) {
+        return new PageDTO<>(
+            page.getNumber() + 1,
+            page.getTotalPages(),
+            page.getNumberOfElements(),
+            page.getTotalElements(),
+            page.getContent()
+        );
+    }
+}

--- a/src/main/java/com/fasttime/domain/review/service/ReviewService.java
+++ b/src/main/java/com/fasttime/domain/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.fasttime.domain.member.exception.MemberNotFoundException;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.review.dto.request.ReviewRequestDTO;
 import com.fasttime.domain.review.dto.response.BootcampReviewSummaryDTO;
+import com.fasttime.domain.review.dto.response.PageDTO;
 import com.fasttime.domain.review.dto.response.ReviewResponseDTO;
 import com.fasttime.domain.review.dto.response.TagSummaryDTO;
 import com.fasttime.domain.review.entity.Review;
@@ -143,7 +144,7 @@ public class ReviewService {
     }
 
     @Cacheable(value = "allReviewsCache")
-    public Page<ReviewResponseDTO> getSortedReviews(String bootcamp, Pageable pageable) {
+    public PageDTO<ReviewResponseDTO> getSortedReviews(String bootcamp, Pageable pageable) {
         Page<Review> reviewPage;
         if (bootcamp != null && !bootcamp.isEmpty()) {
             boolean exists = bootCampRepository.existsByName(bootcamp);
@@ -155,7 +156,8 @@ public class ReviewService {
             reviewPage = reviewRepository.findAll(pageable);
         }
 
-        return reviewPage.map(this::convertToReviewResponseDTO);
+        Page<ReviewResponseDTO> responsePage = reviewPage.map(this::convertToReviewResponseDTO);
+        return PageDTO.fromPage(responsePage);
     }
 
     private ReviewResponseDTO convertToReviewResponseDTO(Review review) {


### PR DESCRIPTION
# Pull Request 요약

- 프론트에서 review 조회시 500에러가 나는 것을 발견. 문제 파악하고 수정하였습니다.

## 변경 사항

### Review 조회 페이지네이션 수정
 - JSON 역직렬화 실패로 인한 문제 발생
 - PageImpl 객체의 기본 생성자가 없어 Jackson이 역직렬화에 실패
 - PageImpl 사용 대신 PageDTO를 직접 반환하여 문제 해결
 - ReviewService에서 Page 객체를 PageDTO로 변환
 - ReviewController에서 PageDTO를 직접 반환하도록 수정

### 관련 테스트 코드 수정


## 개발 유형

- [x] 버그 수정
- [ ] 새로운 기능 개발
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

## 작업 기간

- 작업 시작일: (2024-06-30)
- 작업 종료일: (2024-06-30)


